### PR TITLE
feat: 팝업과 서비스 워커 토글 흐름 구현

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -3,8 +3,38 @@
   <head>
     <meta charset="UTF-8" />
     <title>cgpt-virtualizer</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 0;
+        min-width: 220px;
+        padding: 16px;
+      }
+
+      main {
+        display: grid;
+        gap: 12px;
+      }
+
+      label {
+        align-items: center;
+        display: flex;
+        gap: 8px;
+      }
+
+      p {
+        margin: 0;
+      }
+    </style>
   </head>
   <body>
+    <main>
+      <label for="toggle">
+        <input id="toggle" type="checkbox" disabled />
+        <span>On / Off</span>
+      </label>
+      <p id="status-line" aria-live="polite">Off</p>
+    </main>
     <script type="module" src="./popup.js"></script>
   </body>
 </html>

--- a/src/background/popup-controller.ts
+++ b/src/background/popup-controller.ts
@@ -1,0 +1,31 @@
+import {
+  SET_TAB_ENABLED_MESSAGE_TYPE,
+  createPopupStateMessage,
+  type PopupToWorkerMessage,
+  type WorkerToPopupMessage,
+} from '../shared/messages.ts'
+import { createPopupState, type TabStateStore } from './tab-state.ts'
+
+export interface PopupControllerDependencies {
+  getActiveTabId(): Promise<number | null>
+  refreshActiveTab(tabId: number): Promise<void>
+  tabStateStore: TabStateStore
+}
+
+export async function handlePopupMessage(
+  message: PopupToWorkerMessage,
+  dependencies: PopupControllerDependencies,
+): Promise<WorkerToPopupMessage> {
+  const activeTabId = await dependencies.getActiveTabId()
+
+  if (message.type === SET_TAB_ENABLED_MESSAGE_TYPE && activeTabId !== null) {
+    dependencies.tabStateStore.setTabPreference(activeTabId, message.enabled)
+    await dependencies.refreshActiveTab(activeTabId)
+  }
+
+  const enabled =
+    activeTabId === null ? false : dependencies.tabStateStore.getTabPreference(activeTabId)
+  const popupState = createPopupState(activeTabId, enabled)
+
+  return createPopupStateMessage(popupState.enabled, popupState.status)
+}

--- a/src/background/tab-state.ts
+++ b/src/background/tab-state.ts
@@ -1,0 +1,35 @@
+import type { PopupState } from '../shared/types.ts'
+
+export interface TabStateStore {
+  getTabPreference(tabId: number): boolean
+  setTabPreference(tabId: number, enabled: boolean): void
+}
+
+export function createTabStateStore(
+  initialEntries: Iterable<[number, boolean]> = [],
+): TabStateStore {
+  const preferences = new Map(initialEntries)
+
+  return {
+    getTabPreference(tabId) {
+      return preferences.get(tabId) ?? false
+    },
+    setTabPreference(tabId, enabled) {
+      preferences.set(tabId, enabled)
+    },
+  }
+}
+
+export function createPopupState(tabId: number | null, enabled: boolean): PopupState {
+  if (typeof tabId !== 'number') {
+    return {
+      enabled,
+      status: 'Unavailable',
+    }
+  }
+
+  return {
+    enabled,
+    status: enabled ? 'On' : 'Off',
+  }
+}

--- a/src/chrome.d.ts
+++ b/src/chrome.d.ts
@@ -1,0 +1,43 @@
+interface ChromeLastError {
+  message?: string
+}
+
+interface ChromeRuntimeMessageSender {}
+
+interface ChromeRuntimeOnMessage {
+  addListener(
+    callback: (
+      message: unknown,
+      sender: ChromeRuntimeMessageSender,
+      sendResponse: (response?: unknown) => void,
+    ) => boolean | void,
+  ): void
+}
+
+interface ChromeRuntimeApi {
+  lastError: ChromeLastError | undefined
+  onMessage: ChromeRuntimeOnMessage
+  sendMessage(message: unknown, callback: (response: unknown) => void): void
+}
+
+interface ChromeTab {
+  id?: number
+}
+
+interface ChromeTabsApi {
+  query(
+    queryInfo: {
+      active: boolean
+      currentWindow: boolean
+    },
+    callback: (tabs: ChromeTab[]) => void,
+  ): void
+  reload(tabId: number, callback?: () => void): void
+}
+
+interface ChromeApi {
+  runtime: ChromeRuntimeApi
+  tabs: ChromeTabsApi
+}
+
+declare const chrome: ChromeApi

--- a/src/popup-view.ts
+++ b/src/popup-view.ts
@@ -1,0 +1,15 @@
+import type { WorkerToPopupMessage } from './shared/messages.ts'
+
+export interface PopupViewModel {
+  checked: boolean
+  disabled: boolean
+  statusLine: WorkerToPopupMessage['status']
+}
+
+export function createPopupViewModel(message: WorkerToPopupMessage): PopupViewModel {
+  return {
+    checked: message.enabled,
+    disabled: message.status === 'Unavailable',
+    statusLine: message.status,
+  }
+}

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,11 +1,93 @@
-import { createGetTabStatusMessage } from './shared/messages.ts'
-import { createRuntimeStatus } from './shared/types.ts'
+import {
+  createGetPopupStateMessage,
+  createSetTabEnabledMessage,
+  isWorkerToPopupMessage,
+  type PopupToWorkerMessage,
+  type WorkerToPopupMessage,
+} from './shared/messages.ts'
+import { createPopupViewModel } from './popup-view.ts'
 
-// 팝업 진입점
-const bootstrapStatus = createRuntimeStatus('Off')
-const bootstrapMessage = createGetTabStatusMessage()
+const toggleElement = getToggleElement()
+const statusLineElement = getStatusLineElement()
 
-console.log('cgpt-virtualizer popup loaded', {
-  bootstrapMessage,
-  bootstrapStatus,
+toggleElement.addEventListener('change', () => {
+  void applyToggleChange(toggleElement.checked)
 })
+
+void bootstrapPopup()
+
+async function bootstrapPopup(): Promise<void> {
+  toggleElement.disabled = true
+
+  try {
+    renderPopupState(await sendPopupMessage(createGetPopupStateMessage()))
+  } catch {
+    renderUnavailableState()
+  }
+}
+
+async function applyToggleChange(enabled: boolean): Promise<void> {
+  toggleElement.disabled = true
+
+  try {
+    renderPopupState(await sendPopupMessage(createSetTabEnabledMessage(enabled)))
+  } catch {
+    renderUnavailableState()
+  }
+}
+
+function renderPopupState(message: WorkerToPopupMessage): void {
+  const viewModel = createPopupViewModel(message)
+
+  toggleElement.checked = viewModel.checked
+  toggleElement.disabled = viewModel.disabled
+  statusLineElement.textContent = viewModel.statusLine
+}
+
+function renderUnavailableState(): void {
+  renderPopupState({
+    enabled: false,
+    status: 'Unavailable',
+    type: 'runtime/popup-state',
+  })
+}
+
+function sendPopupMessage(message: PopupToWorkerMessage): Promise<WorkerToPopupMessage> {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(message, (response: unknown) => {
+      const lastError = chrome.runtime.lastError
+
+      if (lastError !== undefined) {
+        reject(new Error(lastError.message ?? '팝업 메시지 전송에 실패했습니다.'))
+        return
+      }
+
+      if (!isWorkerToPopupMessage(response)) {
+        reject(new Error('유효하지 않은 팝업 상태 응답입니다.'))
+        return
+      }
+
+      resolve(response)
+    })
+  })
+}
+
+function getToggleElement(): HTMLInputElement {
+  const element = document.querySelector<HTMLInputElement>('#toggle')
+
+  if (element === null) {
+    throw new Error('팝업 토글 요소를 찾을 수 없습니다.')
+  }
+
+  return element
+}
+
+function getStatusLineElement(): HTMLElement {
+  const element = document.querySelector<HTMLElement>('#status-line')
+
+  if (element === null) {
+    throw new Error('팝업 상태 요소를 찾을 수 없습니다.')
+  }
+
+  return element
+}

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,5 +1,6 @@
 import {
   createGetPopupStateMessage,
+  createPopupStateMessage,
   createSetTabEnabledMessage,
   isWorkerToPopupMessage,
   type PopupToWorkerMessage,
@@ -45,11 +46,7 @@ function renderPopupState(message: WorkerToPopupMessage): void {
 }
 
 function renderUnavailableState(): void {
-  renderPopupState({
-    enabled: false,
-    status: 'Unavailable',
-    type: 'runtime/popup-state',
-  })
+  renderPopupState(createPopupStateMessage(false, 'Unavailable'))
 }
 
 function sendPopupMessage(message: PopupToWorkerMessage): Promise<WorkerToPopupMessage> {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,35 +1,46 @@
-import type { RuntimeStatus, TranscriptSessionId } from './types.ts'
+import type { PopupState } from './types.ts'
 
-export const GET_TAB_STATUS_MESSAGE_TYPE = 'runtime/get-tab-status' as const
-export const TAB_STATUS_MESSAGE_TYPE = 'runtime/tab-status' as const
+export const GET_POPUP_STATE_MESSAGE_TYPE = 'runtime/get-popup-state' as const
+export const SET_TAB_ENABLED_MESSAGE_TYPE = 'runtime/set-tab-enabled' as const
+export const POPUP_STATE_MESSAGE_TYPE = 'runtime/popup-state' as const
 
-export interface GetTabStatusMessage {
-  type: typeof GET_TAB_STATUS_MESSAGE_TYPE
+export interface GetPopupStateMessage {
+  type: typeof GET_POPUP_STATE_MESSAGE_TYPE
 }
 
-export interface TabStatusMessage {
-  conversationId: TranscriptSessionId | null
-  status: RuntimeStatus
-  type: typeof TAB_STATUS_MESSAGE_TYPE
+export interface SetTabEnabledMessage {
+  enabled: boolean
+  type: typeof SET_TAB_ENABLED_MESSAGE_TYPE
 }
 
-export type PopupToWorkerMessage = GetTabStatusMessage
-export type WorkerToPopupMessage = TabStatusMessage
+export interface PopupStateMessage extends PopupState {
+  type: typeof POPUP_STATE_MESSAGE_TYPE
+}
 
-export function createGetTabStatusMessage(): GetTabStatusMessage {
+export type PopupToWorkerMessage = GetPopupStateMessage | SetTabEnabledMessage
+export type WorkerToPopupMessage = PopupStateMessage
+
+export function createGetPopupStateMessage(): GetPopupStateMessage {
   return {
-    type: GET_TAB_STATUS_MESSAGE_TYPE,
+    type: GET_POPUP_STATE_MESSAGE_TYPE,
   }
 }
 
-export function createTabStatusMessage(
-  status: RuntimeStatus,
-  conversationId: TranscriptSessionId | null = null,
-): TabStatusMessage {
+export function createSetTabEnabledMessage(enabled: boolean): SetTabEnabledMessage {
   return {
-    conversationId,
+    enabled,
+    type: SET_TAB_ENABLED_MESSAGE_TYPE,
+  }
+}
+
+export function createPopupStateMessage(
+  enabled: boolean,
+  status: PopupState['status'],
+): PopupStateMessage {
+  return {
+    enabled,
     status,
-    type: TAB_STATUS_MESSAGE_TYPE,
+    type: POPUP_STATE_MESSAGE_TYPE,
   }
 }
 
@@ -38,5 +49,37 @@ export function isPopupToWorkerMessage(value: unknown): value is PopupToWorkerMe
     return false
   }
 
-  return 'type' in value && value.type === GET_TAB_STATUS_MESSAGE_TYPE
+  if (!('type' in value)) {
+    return false
+  }
+
+  if (value.type === GET_POPUP_STATE_MESSAGE_TYPE) {
+    return true
+  }
+
+  if (value.type !== SET_TAB_ENABLED_MESSAGE_TYPE || !('enabled' in value)) {
+    return false
+  }
+
+  return typeof value.enabled === 'boolean'
+}
+
+export function isWorkerToPopupMessage(value: unknown): value is WorkerToPopupMessage {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  if (!('type' in value) || value.type !== POPUP_STATE_MESSAGE_TYPE) {
+    return false
+  }
+
+  if (!('enabled' in value) || typeof value.enabled !== 'boolean') {
+    return false
+  }
+
+  if (!('status' in value)) {
+    return false
+  }
+
+  return value.status === 'On' || value.status === 'Off' || value.status === 'Unavailable'
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,6 +5,11 @@ export type PopupStatus = RuntimeStatus
 export type RuntimeAvailability = Extract<RuntimeStatus, 'On' | 'Unavailable'>
 export type TranscriptSessionId = string
 
+export interface PopupState {
+  enabled: boolean
+  status: PopupStatus
+}
+
 export interface TranscriptPathMatch {
   conversationId: TranscriptSessionId
   pathname: string

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,18 +1,38 @@
 import {
-  createGetTabStatusMessage,
-  createTabStatusMessage,
-  type PopupToWorkerMessage,
-  type WorkerToPopupMessage,
+  isPopupToWorkerMessage,
 } from './shared/messages.ts'
-import { createRuntimeStatus } from './shared/types.ts'
+import { handlePopupMessage } from './background/popup-controller.ts'
+import { createTabStateStore } from './background/tab-state.ts'
 
-const bootstrapRequest: PopupToWorkerMessage = createGetTabStatusMessage()
-const bootstrapResponse: WorkerToPopupMessage = createTabStatusMessage(
-  createRuntimeStatus('Off'),
-)
+const tabStateStore = createTabStateStore()
 
-// 서비스 워커 진입점
-console.log('cgpt-virtualizer worker loaded', {
-  bootstrapRequest,
-  bootstrapResponse,
+chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) => {
+  if (!isPopupToWorkerMessage(message)) {
+    return false
+  }
+
+  void handlePopupMessage(message, {
+    getActiveTabId,
+    refreshActiveTab,
+    tabStateStore,
+  }).then(sendResponse)
+
+  return true
 })
+
+function getActiveTabId(): Promise<number | null> {
+  return new Promise((resolve) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const activeTabId = tabs[0]?.id
+      resolve(typeof activeTabId === 'number' ? activeTabId : null)
+    })
+  })
+}
+
+function refreshActiveTab(tabId: number): Promise<void> {
+  return new Promise((resolve) => {
+    chrome.tabs.reload(tabId, () => {
+      resolve()
+    })
+  })
+}

--- a/tests/unit/popup-worker.test.ts
+++ b/tests/unit/popup-worker.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GET_POPUP_STATE_MESSAGE_TYPE,
+  POPUP_STATE_MESSAGE_TYPE,
+  SET_TAB_ENABLED_MESSAGE_TYPE,
+  createGetPopupStateMessage,
+  createPopupStateMessage,
+  createSetTabEnabledMessage,
+  isPopupToWorkerMessage,
+} from '../../src/shared/messages.ts'
+import { handlePopupMessage } from '../../src/background/popup-controller.ts'
+import { createPopupState, createTabStateStore } from '../../src/background/tab-state.ts'
+import { createPopupViewModel } from '../../src/popup-view.ts'
+
+describe('popup-worker message contracts', () => {
+  it('creates the popup state request message', () => {
+    expect(createGetPopupStateMessage()).toEqual({
+      type: GET_POPUP_STATE_MESSAGE_TYPE,
+    })
+  })
+
+  it('creates the toggle update request message', () => {
+    expect(createSetTabEnabledMessage(true)).toEqual({
+      enabled: true,
+      type: SET_TAB_ENABLED_MESSAGE_TYPE,
+    })
+  })
+
+  it('creates popup state responses with the enabled flag and runtime status', () => {
+    expect(createPopupStateMessage(true, 'On')).toEqual({
+      enabled: true,
+      status: 'On',
+      type: POPUP_STATE_MESSAGE_TYPE,
+    })
+  })
+
+  it('recognizes valid popup-to-worker messages', () => {
+    expect(isPopupToWorkerMessage({ type: GET_POPUP_STATE_MESSAGE_TYPE })).toBe(true)
+    expect(
+      isPopupToWorkerMessage({
+        enabled: false,
+        type: SET_TAB_ENABLED_MESSAGE_TYPE,
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects malformed popup-to-worker messages', () => {
+    expect(isPopupToWorkerMessage({ type: SET_TAB_ENABLED_MESSAGE_TYPE })).toBe(false)
+    expect(
+      isPopupToWorkerMessage({
+        enabled: 'yes',
+        type: SET_TAB_ENABLED_MESSAGE_TYPE,
+      }),
+    ).toBe(false)
+    expect(isPopupToWorkerMessage({ type: 'runtime/unknown' })).toBe(false)
+    expect(isPopupToWorkerMessage(null)).toBe(false)
+  })
+})
+
+describe('tab state store', () => {
+  it('defaults unseen tabs to off', () => {
+    const store = createTabStateStore()
+
+    expect(store.getTabPreference(7)).toBe(false)
+    expect(createPopupState(7, store.getTabPreference(7))).toEqual({
+      enabled: false,
+      status: 'Off',
+    })
+  })
+
+  it('stores preferences by tab id', () => {
+    const store = createTabStateStore()
+
+    store.setTabPreference(7, true)
+    store.setTabPreference(9, false)
+
+    expect(store.getTabPreference(7)).toBe(true)
+    expect(store.getTabPreference(9)).toBe(false)
+    expect(createPopupState(7, store.getTabPreference(7))).toEqual({
+      enabled: true,
+      status: 'On',
+    })
+  })
+
+  it('marks missing active tabs as unavailable', () => {
+    expect(createPopupState(null, false)).toEqual({
+      enabled: false,
+      status: 'Unavailable',
+    })
+  })
+})
+
+describe('popup controller', () => {
+  it('returns off for an active tab with no stored preference', async () => {
+    const store = createTabStateStore()
+
+    await expect(
+      handlePopupMessage(createGetPopupStateMessage(), {
+        getActiveTabId: async () => 7,
+        refreshActiveTab: async () => {},
+        tabStateStore: store,
+      }),
+    ).resolves.toEqual({
+      enabled: false,
+      status: 'Off',
+      type: POPUP_STATE_MESSAGE_TYPE,
+    })
+  })
+
+  it('stores the updated preference and refreshes the active tab', async () => {
+    const refreshedTabIds: number[] = []
+    const store = createTabStateStore()
+
+    await expect(
+      handlePopupMessage(createSetTabEnabledMessage(true), {
+        getActiveTabId: async () => 7,
+        refreshActiveTab: async (tabId) => {
+          refreshedTabIds.push(tabId)
+        },
+        tabStateStore: store,
+      }),
+    ).resolves.toEqual({
+      enabled: true,
+      status: 'On',
+      type: POPUP_STATE_MESSAGE_TYPE,
+    })
+
+    expect(store.getTabPreference(7)).toBe(true)
+    expect(refreshedTabIds).toEqual([7])
+  })
+
+  it('returns unavailable without mutating state when there is no active tab', async () => {
+    const refreshedTabIds: number[] = []
+    const store = createTabStateStore([[7, true]])
+
+    await expect(
+      handlePopupMessage(createSetTabEnabledMessage(false), {
+        getActiveTabId: async () => null,
+        refreshActiveTab: async (tabId) => {
+          refreshedTabIds.push(tabId)
+        },
+        tabStateStore: store,
+      }),
+    ).resolves.toEqual({
+      enabled: false,
+      status: 'Unavailable',
+      type: POPUP_STATE_MESSAGE_TYPE,
+    })
+
+    expect(store.getTabPreference(7)).toBe(true)
+    expect(refreshedTabIds).toEqual([])
+  })
+})
+
+describe('popup view model', () => {
+  it('shows On with an enabled active toggle', () => {
+    expect(
+      createPopupViewModel({
+        enabled: true,
+        status: 'On',
+        type: POPUP_STATE_MESSAGE_TYPE,
+      }),
+    ).toEqual({
+      checked: true,
+      disabled: false,
+      statusLine: 'On',
+    })
+  })
+
+  it('shows Off with an enabled inactive toggle', () => {
+    expect(
+      createPopupViewModel({
+        enabled: false,
+        status: 'Off',
+        type: POPUP_STATE_MESSAGE_TYPE,
+      }),
+    ).toEqual({
+      checked: false,
+      disabled: false,
+      statusLine: 'Off',
+    })
+  })
+
+  it('shows Unavailable with a disabled toggle', () => {
+    expect(
+      createPopupViewModel({
+        enabled: true,
+        status: 'Unavailable',
+        type: POPUP_STATE_MESSAGE_TYPE,
+      }),
+    ).toEqual({
+      checked: true,
+      disabled: true,
+      statusLine: 'Unavailable',
+    })
+  })
+})

--- a/todo.md
+++ b/todo.md
@@ -48,20 +48,20 @@
 
 ## 2. Popup and service worker
 
-- [ ] Implement popup UI with:
-  - [ ] On/Off toggle
-  - [ ] short status line
-- [ ] Implement service worker per-tab state keyed by `tabId`
-- [ ] Implement popup -> worker query for current tab state
-- [ ] Implement popup -> worker toggle update flow
-- [ ] Implement page refresh when toggling On/Off
-- [ ] Handle missing active-tab case safely
-- [ ] Add tests for worker state logic
+- [x] Implement popup UI with:
+  - [x] On/Off toggle
+  - [x] short status line
+- [x] Implement service worker per-tab state keyed by `tabId`
+- [x] Implement popup -> worker query for current tab state
+- [x] Implement popup -> worker toggle update flow
+- [x] Implement page refresh when toggling On/Off
+- [x] Handle missing active-tab case safely
+- [x] Add tests for worker state logic
 
 ### Acceptance criteria
-- [ ] Toggle state updates for active tab
-- [ ] Toggling refreshes the page
-- [ ] Popup can show `On`, `Off`, or `Unavailable`
+- [x] Toggle state updates for active tab
+- [x] Toggling refreshes the page
+- [x] Popup can show `On`, `Off`, or `Unavailable`
 
 ---
 


### PR DESCRIPTION
## 요약
- 팝업에 On/Off 토글과 짧은 상태 줄을 추가했습니다.
- 서비스 워커에 탭별 메모리 상태, 상태 조회, 토글 변경, 새로고침 흐름을 구현했습니다.
- 메시지 계약, 워커 제어 로직, 팝업 표시 상태를 단위 테스트로 검증하고 `todo.md`를 동기화했습니다.

## 테스트
- pnpm run build
- pnpm run test

## 관련 이슈
- #5