### PR TITLE
docs: Codex 멀티 에이전트 운영 규칙 정렬

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,10 +63,18 @@ Rule #1: If you want exception to ANY rule, YOU MUST STOP and get explicit permi
 
 ## Agent Delegation
 
-- The main conversation acts as coordinator; spawned agents handle bounded support tasks
-- Prefer spawning agents for: parallel research, batch operations, verbose output (logs, test suites)
-- Keep in the main conversation: implementation, iterative work, decisions requiring context
-- Agents don't share context with each other — route information through the main conversation
+- The main conversation acts as COORDINATOR — it plans, decides, synthesizes, integrates, and handles Ori-facing judgment
+- Spawned agents are bounded WORKERS — they should advance parallel sidecar tasks, not replace coordinator responsibility
+- Prefer `explorer` for read-only research: broad codebase search, dependency tracing, long-file analysis, git history, and similar context gathering
+- Prefer `worker` for bounded execution: isolated implementation slices, test runs, lint/typecheck, log analysis, and other verbose verification
+- Use `default` only when neither `explorer` nor `worker` is a clean fit
+- Delegate only sidecar tasks that do not block the immediate next local step; keep urgent critical-path work in the main conversation
+- Keep in the main conversation: architecture decisions, plan approval, conflict resolution, iterative integration, and anything requiring Ori's input or approval
+- Agent prompts MUST be self-contained and include: goal, scope, constraints, exact files or ownership, expected output, and acceptance checks
+- Agents do not share context with each other — route information through the main conversation and explicitly pass along any needed results
+- When delegating code changes, assign disjoint ownership and tell workers they are not alone in the codebase so they avoid reverting unrelated edits
+- Parallelize independent tasks aggressively, but NEVER duplicate the same unresolved work across multiple agents
+- NEVER wait immediately by reflex after spawning agents; continue non-overlapping local work and wait only when the next step is blocked on the result
 
 ## Planning and Task handling
 


### PR DESCRIPTION
## 요약

- `AGENTS.md`의 `Agent Delegation` 섹션을 현재 Codex 멀티 에이전트 아키텍처에 맞게 구체화했습니다.
- `explorer` / `worker` / `default` 역할 기준, 병렬화 기준, 소유권 규칙, `wait` 사용 기준을 명시했습니다.
- `~/.codex/config.toml`에서 `multi_agent = true` 상태를 확인했습니다.

## 관련 이슈

- Closes #29

## 검증

- `git diff -- AGENTS.md`
- `sed -n '1,80p' /Users/ori/.codex/config.toml`
- `rg -n "multi_agent" /Users/ori/.codex/config.toml`

## 비고

- `config.toml`에는 이미 `multi_agent = true`가 설정되어 있어, 지원되지 않는 추측성 설정은 추가하지 않았습니다.
- 현재 Codex 세션은 이미 시작된 상태이므로, 수정된 워크스페이스 컨텍스트의 실효 검증은 새 세션에서 확인해야 합니다.
