### PR TITLE
작업 5: 측정 상태와 prefix sum 계층 구축

### DIFF
--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -2,7 +2,14 @@ import { createReportContentAvailabilityMessage } from '../shared/messages.ts'
 import type { ContentAvailability } from '../shared/types.ts'
 import { isSupportedTranscriptPath } from '../shared/routes.ts'
 import { resolveAvailability } from './availability.ts'
+import { measureBubble } from './measure.ts'
+import { buildPrefixSums } from './prefix-sums.ts'
 import { resolveSelectors } from './selectors.ts'
+import {
+  buildBubbleRecords,
+  createSessionState,
+  type TranscriptSessionState,
+} from './state.ts'
 import { scanTranscript, type TranscriptScanResult } from './transcript-scan.ts'
 
 export interface ContentBootstrapDependencies {
@@ -14,6 +21,7 @@ export interface ContentBootstrapDependencies {
 export interface ContentBootstrapResult {
   availability: ContentAvailability
   scanResult: TranscriptScanResult | null
+  sessionState: TranscriptSessionState | null
 }
 
 export function bootstrapContentScript(
@@ -28,10 +36,14 @@ export function bootstrapContentScript(
     baseAvailability === 'available' && scanResult !== null && !scanResult.activationEligible
       ? 'inactive'
       : baseAvailability
+  const sessionState =
+    availability === 'available' && selectors !== null && scanResult !== null
+      ? createTranscriptSessionState(selectors.scrollContainer, scanResult)
+      : null
 
   dependencies.reportAvailability(createReportContentAvailabilityMessage(availability))
 
-  return { availability, scanResult }
+  return { availability, scanResult, sessionState }
 }
 
 function createDefaultDependencies(): ContentBootstrapDependencies {
@@ -42,4 +54,18 @@ function createDefaultDependencies(): ContentBootstrapDependencies {
       chrome.runtime.sendMessage(message)
     },
   }
+}
+
+function createTranscriptSessionState(
+  scrollContainer: HTMLElement,
+  scanResult: TranscriptScanResult,
+): TranscriptSessionState {
+  const records = buildBubbleRecords(scanResult.bubbles, measureBubble)
+
+  return createSessionState(
+    scanResult.transcriptRoot,
+    scrollContainer,
+    records,
+    buildPrefixSums(records),
+  )
 }

--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -7,7 +7,6 @@ import { buildPrefixSums } from './prefix-sums.ts'
 import { resolveSelectors } from './selectors.ts'
 import {
   buildBubbleRecords,
-  createSessionState,
   type TranscriptSessionState,
 } from './state.ts'
 import { scanTranscript, type TranscriptScanResult } from './transcript-scan.ts'
@@ -62,10 +61,10 @@ function createTranscriptSessionState(
 ): TranscriptSessionState {
   const records = buildBubbleRecords(scanResult.bubbles, measureBubble)
 
-  return createSessionState(
-    scanResult.transcriptRoot,
+  return {
+    transcriptRoot: scanResult.transcriptRoot,
     scrollContainer,
     records,
-    buildPrefixSums(records),
-  )
+    prefixSums: buildPrefixSums(records),
+  }
 }

--- a/src/content/measure.ts
+++ b/src/content/measure.ts
@@ -1,0 +1,3 @@
+export function measureBubble(node: Element): number {
+  return node.getBoundingClientRect().height
+}

--- a/src/content/prefix-sums.ts
+++ b/src/content/prefix-sums.ts
@@ -1,0 +1,35 @@
+import type { BubbleRecord } from './state.ts'
+
+export function buildPrefixSums(records: BubbleRecord[]): number[] {
+  let total = 0
+
+  return records.map((record) => {
+    total += record.measuredHeight
+    return total
+  })
+}
+
+export function rebuildPrefixSumsFromIndex(
+  prefixSums: number[],
+  records: BubbleRecord[],
+  changedIndex: number,
+): number[] {
+  if (
+    records.length === 0 ||
+    changedIndex <= 0 ||
+    changedIndex >= records.length ||
+    prefixSums.length !== records.length
+  ) {
+    return buildPrefixSums(records)
+  }
+
+  const rebuilt = prefixSums.slice(0, changedIndex)
+  let total = rebuilt[changedIndex - 1] ?? 0
+
+  for (let index = changedIndex; index < records.length; index += 1) {
+    total += records[index].measuredHeight
+    rebuilt[index] = total
+  }
+
+  return rebuilt
+}

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -26,16 +26,3 @@ export function buildBubbleRecords(
   }))
 }
 
-export function createSessionState(
-  transcriptRoot: HTMLElement,
-  scrollContainer: HTMLElement,
-  records: BubbleRecord[],
-  prefixSums: number[],
-): TranscriptSessionState {
-  return {
-    transcriptRoot,
-    scrollContainer,
-    records,
-    prefixSums,
-  }
-}

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -1,0 +1,41 @@
+export interface BubbleRecord {
+  index: number
+  node: Element
+  measuredHeight: number
+  mounted: boolean
+  pinned: boolean
+}
+
+export interface TranscriptSessionState {
+  transcriptRoot: HTMLElement
+  scrollContainer: HTMLElement
+  records: BubbleRecord[]
+  prefixSums: number[]
+}
+
+export function buildBubbleRecords(
+  bubbles: Element[],
+  measure: (node: Element) => number,
+): BubbleRecord[] {
+  return bubbles.map((node, index) => ({
+    index,
+    node,
+    measuredHeight: measure(node),
+    mounted: false,
+    pinned: false,
+  }))
+}
+
+export function createSessionState(
+  transcriptRoot: HTMLElement,
+  scrollContainer: HTMLElement,
+  records: BubbleRecord[],
+  prefixSums: number[],
+): TranscriptSessionState {
+  return {
+    transcriptRoot,
+    scrollContainer,
+    records,
+    prefixSums,
+  }
+}

--- a/tests/unit/content-bootstrap.test.ts
+++ b/tests/unit/content-bootstrap.test.ts
@@ -58,6 +58,7 @@ describe('selector resolution', () => {
 
     expect(result.availability).toBe('idle')
     expect(result.scanResult).toBeNull()
+    expect(result.sessionState).toBeNull()
 
     expect(reports).toEqual([
       {
@@ -100,6 +101,7 @@ describe('transcript scan integration', () => {
     })
 
     expect(result.scanResult).toBeNull()
+    expect(result.sessionState).toBeNull()
   })
 
   it('returns null scanResult when selectors are missing', () => {
@@ -113,6 +115,7 @@ describe('transcript scan integration', () => {
 
     expect(result.availability).toBe('unavailable')
     expect(result.scanResult).toBeNull()
+    expect(result.sessionState).toBeNull()
   })
 
   it('returns scanResult with activationEligible=false for 0 bubbles', () => {
@@ -127,6 +130,7 @@ describe('transcript scan integration', () => {
 
     expect(result.availability).toBe('inactive')
     expect(result.scanResult).not.toBeNull()
+    expect(result.sessionState).toBeNull()
     expect(result.scanResult?.bubbleCount).toBe(0)
     expect(result.scanResult?.activationEligible).toBe(false)
     expect(reports).toEqual([
@@ -148,6 +152,7 @@ describe('transcript scan integration', () => {
     })
 
     expect(result.availability).toBe('inactive')
+    expect(result.sessionState).toBeNull()
     expect(result.scanResult?.bubbleCount).toBe(49)
     expect(result.scanResult?.activationEligible).toBe(false)
     expect(reports).toEqual([
@@ -169,4 +174,80 @@ describe('transcript scan integration', () => {
     expect(result.scanResult?.bubbleCount).toBe(50)
     expect(result.scanResult?.activationEligible).toBe(true)
   })
+
+  it('creates ordered session state with measured heights for eligible transcripts', () => {
+    const bubbleHeights = Array.from({ length: 50 }, (_, index) => index + 0.5)
+    const fixture = makeMeasuredDocumentFixture(bubbleHeights)
+
+    const result = bootstrapContentScript({
+      document: fixture.document,
+      pathname: '/c/example',
+      reportAvailability() {},
+    })
+
+    expect(result.availability).toBe('available')
+    expect(result.sessionState).not.toBeNull()
+    expect(result.sessionState?.transcriptRoot).toBe(fixture.transcriptRoot)
+    expect(result.sessionState?.scrollContainer).toBe(fixture.scrollContainer)
+    expect(result.sessionState?.records).toHaveLength(50)
+    expect(result.sessionState?.records[0]).toMatchObject({
+      index: 0,
+      measuredHeight: 0.5,
+      mounted: false,
+      pinned: false,
+    })
+    expect(result.sessionState?.records[1]).toMatchObject({
+      index: 1,
+      measuredHeight: 1.5,
+      mounted: false,
+      pinned: false,
+    })
+    expect(result.sessionState?.records[49]).toMatchObject({
+      index: 49,
+      measuredHeight: 49.5,
+      mounted: false,
+      pinned: false,
+    })
+    expect(result.sessionState?.records[0]?.node).toBe(fixture.bubbles[0])
+    expect(result.sessionState?.records[1]?.node).toBe(fixture.bubbles[1])
+    expect(result.sessionState?.records[49]?.node).toBe(fixture.bubbles[49])
+    expect(result.sessionState?.prefixSums[0]).toBe(0.5)
+    expect(result.sessionState?.prefixSums[1]).toBe(2)
+    expect(result.sessionState?.prefixSums[49]).toBe(1250)
+  })
 })
+
+function makeMeasuredDocumentFixture(bubbleHeights: number[]): {
+  bubbles: HTMLElement[]
+  document: Document
+  scrollContainer: HTMLElement
+  transcriptRoot: HTMLElement
+} {
+  const transcriptRoot = document.createElement('section')
+  transcriptRoot.setAttribute('data-cgpt-transcript-root', '')
+  const scrollContainer = document.createElement('main')
+  scrollContainer.setAttribute('data-cgpt-scroll-container', '')
+  const bubbles = bubbleHeights.map((height) => {
+    const bubble = document.createElement('article')
+    bubble.setAttribute('data-cgpt-transcript-bubble', '')
+    bubble.getBoundingClientRect = () => ({ height }) as DOMRect
+    transcriptRoot.append(bubble)
+    return bubble
+  })
+  const streamingIndicator = document.createElement('div')
+  streamingIndicator.setAttribute('data-cgpt-streaming-indicator', '')
+
+  const body = document.createElement('body')
+  body.append(scrollContainer, transcriptRoot, streamingIndicator)
+
+  return {
+    bubbles,
+    document: {
+      querySelector(selector: string) {
+        return body.querySelector(selector)
+      },
+    } as unknown as Document,
+    scrollContainer,
+    transcriptRoot,
+  }
+}

--- a/tests/unit/measurement-prefix-sums.test.ts
+++ b/tests/unit/measurement-prefix-sums.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import { measureBubble } from '../../src/content/measure.ts'
+import {
+  buildPrefixSums,
+  rebuildPrefixSumsFromIndex,
+} from '../../src/content/prefix-sums.ts'
+import type { BubbleRecord } from '../../src/content/state.ts'
+
+function makeBubbleRecord(index: number, measuredHeight: number): BubbleRecord {
+  return {
+    index,
+    measuredHeight,
+    mounted: false,
+    node: document.createElement('article'),
+    pinned: false,
+  }
+}
+
+describe('measureBubble', () => {
+  it('returns the floating-point DOM height', () => {
+    const bubble = document.createElement('article')
+    bubble.getBoundingClientRect = () => ({ height: 123.45 }) as DOMRect
+
+    expect(measureBubble(bubble)).toBe(123.45)
+  })
+})
+
+describe('buildPrefixSums', () => {
+  it('returns empty prefix sums for an empty record list', () => {
+    expect(buildPrefixSums([])).toEqual([])
+  })
+
+  it('builds cumulative heights from ordered records', () => {
+    const records = [
+      makeBubbleRecord(0, 10.25),
+      makeBubbleRecord(1, 20.5),
+      makeBubbleRecord(2, 5.75),
+    ]
+
+    expect(buildPrefixSums(records)).toEqual([10.25, 30.75, 36.5])
+  })
+})
+
+describe('rebuildPrefixSumsFromIndex', () => {
+  it('recomputes only the changed suffix values', () => {
+    const records = [
+      makeBubbleRecord(0, 10),
+      makeBubbleRecord(1, 20),
+      makeBubbleRecord(2, 30),
+      makeBubbleRecord(3, 40),
+    ]
+    const prefixSums = buildPrefixSums(records)
+
+    records[2] = makeBubbleRecord(2, 35.5)
+    records[3] = makeBubbleRecord(3, 45.25)
+
+    expect(rebuildPrefixSumsFromIndex(prefixSums, records, 2)).toEqual([10, 30, 65.5, 110.75])
+    expect(prefixSums).toEqual([10, 30, 60, 100])
+  })
+})

--- a/tests/unit/measurement-prefix-sums.test.ts
+++ b/tests/unit/measurement-prefix-sums.test.ts
@@ -59,4 +59,29 @@ describe('rebuildPrefixSumsFromIndex', () => {
     expect(rebuildPrefixSumsFromIndex(prefixSums, records, 2)).toEqual([10, 30, 65.5, 110.75])
     expect(prefixSums).toEqual([10, 30, 60, 100])
   })
+
+  it('falls back to a full rebuild when records are empty', () => {
+    expect(rebuildPrefixSumsFromIndex([], [], 0)).toEqual([])
+  })
+
+  it('falls back to a full rebuild when changedIndex is 0', () => {
+    const records = [makeBubbleRecord(0, 20), makeBubbleRecord(1, 30)]
+    const stalePrefixSums = [10, 30]
+
+    expect(rebuildPrefixSumsFromIndex(stalePrefixSums, records, 0)).toEqual([20, 50])
+  })
+
+  it('falls back to a full rebuild when changedIndex equals records length', () => {
+    const records = [makeBubbleRecord(0, 10), makeBubbleRecord(1, 20)]
+    const prefixSums = buildPrefixSums(records)
+
+    expect(rebuildPrefixSumsFromIndex(prefixSums, records, 2)).toEqual([10, 30])
+  })
+
+  it('falls back to a full rebuild when prefixSums and records lengths differ', () => {
+    const records = [makeBubbleRecord(0, 10), makeBubbleRecord(1, 20)]
+    const stalePrefixSums = [10]
+
+    expect(rebuildPrefixSumsFromIndex(stalePrefixSums, records, 1)).toEqual([10, 30])
+  })
 })

--- a/todo.md
+++ b/todo.md
@@ -111,19 +111,19 @@
 
 ## 5. Measurement and prefix sums
 
-- [ ] Define `BubbleRecord`
-- [ ] Add measurement wrapper using `getBoundingClientRect().height`
-- [ ] Store floating-point heights
-- [ ] Build prefix-sum array from BubbleRecords
-- [ ] Implement suffix rebuild from changed index
-- [ ] Define transcript session state shape
-- [ ] Wire scan -> records -> measurement -> prefix sums
-- [ ] Add unit tests for prefix sums and suffix rebuild
+- [x] Define `BubbleRecord`
+- [x] Add measurement wrapper using `getBoundingClientRect().height`
+- [x] Store floating-point heights
+- [x] Build prefix-sum array from BubbleRecords
+- [x] Implement suffix rebuild from changed index
+- [x] Define transcript session state shape
+- [x] Wire scan -> records -> measurement -> prefix sums
+- [x] Add unit tests for prefix sums and suffix rebuild
 
 ### Acceptance criteria
-- [ ] All eligible bubbles are measured into ordered records
-- [ ] Prefix sums are correct
-- [ ] Suffix updates work correctly after a changed index
+- [x] All eligible bubbles are measured into ordered records
+- [x] Prefix sums are correct
+- [x] Suffix updates work correctly after a changed index
 
 ---
 


### PR DESCRIPTION
## 요약
- transcript session state와 BubbleRecord를 추가했습니다.
- bubble 높이 측정과 prefix sum 계산 및 suffix rebuild 경로를 추가했습니다.
- bootstrap, 단위 테스트, todo.md를 이번 이슈 범위에 맞게 갱신했습니다.

## 테스트
- `pnpm run test:unit`
- `pnpm run test:integration`

Closes #8