### PR TITLE
feat: 앵커 기반 스크롤 보정 추가

### DIFF
--- a/src/content/anchor.ts
+++ b/src/content/anchor.ts
@@ -1,0 +1,87 @@
+import type { BubbleRecord } from './state.ts'
+
+export interface AnchorSnapshot {
+  index: number
+  node: Element
+  offset: number
+}
+
+export interface ViewportRect {
+  top: number
+  bottom: number
+}
+
+export function selectAnchorBubble(
+  mountedRecords: BubbleRecord[],
+  viewportRect: ViewportRect,
+): BubbleRecord | null {
+  for (const record of mountedRecords) {
+    if (!record.mounted) {
+      continue
+    }
+
+    const rect = record.node.getBoundingClientRect()
+
+    if (rect.bottom > viewportRect.top && rect.top < viewportRect.bottom) {
+      return record
+    }
+  }
+
+  return null
+}
+
+export function computeAnchorOffset(anchorNode: Element, viewportTop: number): number {
+  return anchorNode.getBoundingClientRect().top - viewportTop
+}
+
+export function captureAnchorSnapshot(
+  mountedRecords: BubbleRecord[],
+  viewportRect: ViewportRect,
+): AnchorSnapshot | null {
+  const anchorBubble = selectAnchorBubble(mountedRecords, viewportRect)
+
+  if (anchorBubble === null) {
+    return null
+  }
+
+  return {
+    index: anchorBubble.index,
+    node: anchorBubble.node,
+    offset: computeAnchorOffset(anchorBubble.node, viewportRect.top),
+  }
+}
+
+export function accumulateScrollCorrection(
+  currentCorrection: number,
+  anchor: AnchorSnapshot | null,
+  changedIndex: number,
+  heightDelta: number,
+): number {
+  if (anchor === null || changedIndex >= anchor.index) {
+    return currentCorrection
+  }
+
+  return currentCorrection + heightDelta
+}
+
+export function resolveAnchorCorrection(
+  anchor: AnchorSnapshot | null,
+  viewportTop: number,
+): number {
+  if (anchor === null || !anchor.node.isConnected) {
+    return 0
+  }
+
+  return computeAnchorOffset(anchor.node, viewportTop) - anchor.offset
+}
+
+export function applyScrollCorrection(
+  scrollContainer: HTMLElement,
+  correction: number,
+): void {
+  if (correction === 0) {
+    return
+  }
+
+  scrollContainer.scrollTop += correction
+}

--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -73,7 +73,9 @@ function createTranscriptSessionState(
   const records = buildBubbleRecords(scanResult.bubbles, measureBubble)
 
   return {
+    anchor: null,
     transcriptRoot: scanResult.transcriptRoot,
+    pendingScrollCorrection: 0,
     scrollContainer,
     records,
     prefixSums: buildPrefixSums(records),

--- a/src/content/scroll.ts
+++ b/src/content/scroll.ts
@@ -1,3 +1,9 @@
+import {
+  applyScrollCorrection,
+  captureAnchorSnapshot,
+  resolveAnchorCorrection,
+  type ViewportRect,
+} from './anchor.ts'
 import { OVERSCAN_VIEWPORT_COUNT } from '../shared/constants.ts'
 import { patchMountedRange } from './patch.ts'
 import { findRangeByScrollPosition, shouldSchedulePatch } from './range.ts'
@@ -43,7 +49,7 @@ export function initializeScrollVirtualization(
 
       const rangeToApply = queuedRange
       queuedRange = null
-      patchMountedRange(state, rangeToApply.start, rangeToApply.end)
+      applyMountedRangeUpdate(state, rangeToApply)
     })
   }
 
@@ -73,6 +79,35 @@ function getMountedRangeForScrollPosition(
   )
 }
 
+export function applyMountedRangeUpdate(
+  state: TranscriptSessionState,
+  range: MountedRange,
+): void {
+  const viewportRect = resolveViewportRect(state.scrollContainer)
+  const anchor = captureAnchorSnapshot(state.records, viewportRect)
+
+  patchMountedRange(state, range.start, range.end)
+
+  const correction =
+    anchor === null
+      ? 0
+      : state.pendingScrollCorrection + resolveAnchorCorrection(anchor, viewportRect.top)
+
+  applyScrollCorrection(state.scrollContainer, correction)
+  state.pendingScrollCorrection = 0
+  state.anchor = captureAnchorSnapshot(state.records, resolveViewportRect(state.scrollContainer))
+}
+
 function resolveViewportHeight(scrollContainer: HTMLElement): number {
   return scrollContainer.clientHeight || scrollContainer.getBoundingClientRect().height
+}
+
+function resolveViewportRect(scrollContainer: HTMLElement): ViewportRect {
+  const rect = scrollContainer.getBoundingClientRect()
+  const height = resolveViewportHeight(scrollContainer)
+
+  return {
+    bottom: rect.top + height,
+    top: rect.top,
+  }
 }

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -1,3 +1,5 @@
+import type { AnchorSnapshot } from './anchor.ts'
+
 export interface BubbleRecord {
   index: number
   node: Element
@@ -17,6 +19,8 @@ export interface TranscriptSessionState {
   records: BubbleRecord[]
   prefixSums: number[]
   mountedRange: MountedRange | null
+  anchor: AnchorSnapshot | null
+  pendingScrollCorrection: number
 }
 
 export function buildBubbleRecords(

--- a/tests/unit/content-anchor.test.ts
+++ b/tests/unit/content-anchor.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import {
+  accumulateScrollCorrection,
+  applyScrollCorrection,
+  captureAnchorSnapshot,
+  computeAnchorOffset,
+  resolveAnchorCorrection,
+  selectAnchorBubble,
+} from '../../src/content/anchor.ts'
+import type { BubbleRecord } from '../../src/content/state.ts'
+
+describe('selectAnchorBubble', () => {
+  it('returns the first mounted bubble intersecting the viewport', () => {
+    const records = [
+      makeBubbleRecord(0, { top: -80, bottom: -20 }),
+      makeBubbleRecord(1, { top: -10, bottom: 40 }),
+      makeBubbleRecord(2, { top: 20, bottom: 80 }),
+    ]
+
+    expect(selectAnchorBubble(records, { top: 0, bottom: 60 })?.index).toBe(1)
+  })
+
+  it('ignores unmounted bubbles and returns null when nothing intersects', () => {
+    const records = [
+      makeBubbleRecord(0, { top: 0, bottom: 40 }, false),
+      makeBubbleRecord(1, { top: 80, bottom: 120 }),
+    ]
+
+    expect(selectAnchorBubble(records, { top: 0, bottom: 60 })).toBeNull()
+    expect(captureAnchorSnapshot(records, { top: 0, bottom: 60 })).toBeNull()
+  })
+})
+
+describe('computeAnchorOffset', () => {
+  it('measures the distance from the viewport top to the anchor bubble', () => {
+    const record = makeBubbleRecord(0, { top: 124, bottom: 184 })
+
+    expect(computeAnchorOffset(record.node, 100)).toBe(24)
+  })
+})
+
+describe('accumulateScrollCorrection', () => {
+  it('adds height deltas only for bubbles above the anchor', () => {
+    const anchor = captureAnchorSnapshot(
+      [
+        makeBubbleRecord(0, { top: -20, bottom: 20 }),
+        makeBubbleRecord(1, { top: 20, bottom: 60 }),
+        makeBubbleRecord(2, { top: 60, bottom: 100 }),
+      ],
+      { top: 0, bottom: 80 },
+    )
+
+    expect(anchor?.index).toBe(0)
+    expect(accumulateScrollCorrection(5, anchor, 0, 12)).toBe(5)
+    expect(accumulateScrollCorrection(5, anchor, 1, 12)).toBe(5)
+
+    const laterAnchor = {
+      index: 2,
+      node: document.createElement('article'),
+      offset: 10,
+    }
+
+    expect(accumulateScrollCorrection(5, laterAnchor, 1, 12)).toBe(17)
+  })
+})
+
+describe('resolveAnchorCorrection', () => {
+  it('returns zero when there is no valid anchor snapshot', () => {
+    expect(resolveAnchorCorrection(null, 100)).toBe(0)
+
+    const disconnectedAnchor = {
+      index: 0,
+      node: document.createElement('article'),
+      offset: 12,
+    }
+
+    expect(resolveAnchorCorrection(disconnectedAnchor, 100)).toBe(0)
+  })
+
+  it('returns the post-patch offset drift for a connected anchor node', () => {
+    const record = makeBubbleRecord(0, { top: 145, bottom: 205 })
+    document.body.replaceChildren(record.node)
+
+    expect(
+      resolveAnchorCorrection(
+        {
+          index: 0,
+          node: record.node,
+          offset: 20,
+        },
+        100,
+      ),
+    ).toBe(25)
+  })
+})
+
+describe('applyScrollCorrection', () => {
+  it('adds the correction to scrollTop and ignores zero deltas', () => {
+    const scrollContainer = document.createElement('main')
+    scrollContainer.scrollTop = 120
+
+    applyScrollCorrection(scrollContainer, 25)
+    applyScrollCorrection(scrollContainer, 0)
+
+    expect(scrollContainer.scrollTop).toBe(145)
+  })
+})
+
+function makeBubbleRecord(
+  index: number,
+  rect: { bottom: number; top: number },
+  mounted = true,
+): BubbleRecord {
+  const node = document.createElement('article')
+  node.getBoundingClientRect = () => ({ ...rect } as DOMRect)
+
+  return {
+    index,
+    measuredHeight: rect.bottom - rect.top,
+    mounted,
+    node,
+    pinned: false,
+  }
+}

--- a/tests/unit/content-patch.test.ts
+++ b/tests/unit/content-patch.test.ts
@@ -92,7 +92,9 @@ function makeSessionFixture(heights: number[]): {
   return {
     bubbles,
     sessionState: {
+      anchor: null,
       mountedRange: null,
+      pendingScrollCorrection: 0,
       prefixSums: [10, 30, 60, 100].slice(0, heights.length),
       records,
       scrollContainer,

--- a/tests/unit/content-scroll.test.ts
+++ b/tests/unit/content-scroll.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import {
+  accumulateScrollCorrection,
+  captureAnchorSnapshot,
+} from '../../src/content/anchor.ts'
+import { applyMountedRangeUpdate } from '../../src/content/scroll.ts'
+import type { BubbleRecord, TranscriptSessionState } from '../../src/content/state.ts'
+
+describe('applyMountedRangeUpdate', () => {
+  it('captures the first intersecting mounted bubble after patching', () => {
+    const fixture = makeSessionFixture([100, 100, 100, 100], {
+      scrollTop: 0,
+      viewportHeight: 100,
+      viewportTop: 50,
+    })
+
+    applyMountedRangeUpdate(fixture.sessionState, { start: 0, end: 2 })
+
+    expect(fixture.sessionState.mountedRange).toEqual({ start: 0, end: 2 })
+    expect(fixture.sessionState.anchor).toEqual({
+      index: 0,
+      node: fixture.bubbles[0],
+      offset: 0,
+    })
+  })
+
+  it('applies accumulated correction during the patch frame when the anchor survives', () => {
+    const fixture = makeSessionFixture([100, 100, 100, 100, 100], {
+      scrollTop: 0,
+      viewportHeight: 100,
+      viewportTop: 50,
+    })
+
+    applyMountedRangeUpdate(fixture.sessionState, { start: 0, end: 3 })
+
+    fixture.scrollContainer.scrollTop = 250
+
+    const currentAnchor = captureAnchorSnapshot(fixture.sessionState.records, {
+      top: 50,
+      bottom: 150,
+    })
+
+    fixture.sessionState.pendingScrollCorrection = accumulateScrollCorrection(
+      0,
+      currentAnchor,
+      0,
+      25,
+    )
+
+    applyMountedRangeUpdate(fixture.sessionState, { start: 1, end: 4 })
+
+    expect(fixture.scrollContainer.scrollTop).toBe(275)
+    expect(fixture.sessionState.pendingScrollCorrection).toBe(0)
+    expect(fixture.sessionState.anchor?.index).toBe(2)
+  })
+})
+
+function makeSessionFixture(
+  heights: number[],
+  options: {
+    scrollTop: number
+    viewportHeight: number
+    viewportTop: number
+  },
+): {
+  bubbles: HTMLElement[]
+  scrollContainer: HTMLElement
+  sessionState: TranscriptSessionState
+} {
+  document.body.innerHTML = ''
+
+  const transcriptRoot = document.createElement('section')
+  const scrollContainer = document.createElement('main')
+  const prefixSums = buildPrefixSums(heights)
+  const bubbles = heights.map((height, index) => {
+    const bubble = document.createElement('article')
+    const top = index === 0 ? 0 : (prefixSums[index - 1] ?? 0)
+
+    bubble.textContent = `Bubble ${index}`
+    bubble.getBoundingClientRect = () =>
+      ({
+        bottom: options.viewportTop + top - scrollContainer.scrollTop + height,
+        height,
+        top: options.viewportTop + top - scrollContainer.scrollTop,
+      }) as DOMRect
+    transcriptRoot.append(bubble)
+    return bubble
+  })
+  const records = bubbles.map((bubble, index): BubbleRecord => ({
+    index,
+    measuredHeight: heights[index],
+    mounted: false,
+    node: bubble,
+    pinned: false,
+  }))
+
+  Object.defineProperty(scrollContainer, 'clientHeight', {
+    configurable: true,
+    value: options.viewportHeight,
+  })
+
+  scrollContainer.scrollTop = options.scrollTop
+  scrollContainer.getBoundingClientRect = () =>
+    ({
+      height: options.viewportHeight,
+      top: options.viewportTop,
+    }) as DOMRect
+
+  scrollContainer.append(transcriptRoot)
+  document.body.append(scrollContainer)
+
+  return {
+    bubbles,
+    scrollContainer,
+    sessionState: {
+      anchor: null,
+      mountedRange: null,
+      pendingScrollCorrection: 0,
+      prefixSums,
+      records,
+      scrollContainer,
+      transcriptRoot,
+    },
+  }
+}
+
+function buildPrefixSums(heights: number[]): number[] {
+  return heights.reduce<number[]>((prefixSums, height) => {
+    const previous = prefixSums[prefixSums.length - 1] ?? 0
+
+    prefixSums.push(previous + height)
+    return prefixSums
+  }, [])
+}

--- a/todo.md
+++ b/todo.md
@@ -171,18 +171,18 @@
 
 ## 8. Anchor model and scroll correction
 
-- [ ] Implement anchor selection:
-  - [ ] first mounted bubble intersecting viewport
-- [ ] Implement anchor offset calculation
-- [ ] Implement correction accumulation rules
-- [ ] Handle no-anchor fallback safely
-- [ ] Integrate anchor recomputation into patch frame flow
-- [ ] Add unit tests for anchor math and correction logic
+- [x] Implement anchor selection:
+  - [x] first mounted bubble intersecting viewport
+- [x] Implement anchor offset calculation
+- [x] Implement correction accumulation rules
+- [x] Handle no-anchor fallback safely
+- [x] Integrate anchor recomputation into patch frame flow
+- [x] Add unit tests for anchor math and correction logic
 
 ### Acceptance criteria
-- [ ] Anchor bubble selection is correct
-- [ ] Offset calculation is correct
-- [ ] No-anchor case behaves safely
+- [x] Anchor bubble selection is correct
+- [x] Offset calculation is correct
+- [x] No-anchor case behaves safely
 
 ---
 


### PR DESCRIPTION
## 요약
- anchor 선택, offset 계산, 보정 누적/적용 헬퍼를 추가합니다.
- scroll patch frame에서 패치 전 anchor를 캡처하고 패치 후 보정을 적용하도록 연결합니다.
- 관련 단위 테스트를 추가하고 todo.md 8번 섹션을 검증 결과에 맞춰 갱신합니다.

## 테스트
- pnpm run test

Closes #11