### PR TITLE
작업 9: ResizeObserver 통합

### DIFF
--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -4,7 +4,14 @@ import { isSupportedTranscriptPath } from '../shared/routes.ts'
 import { resolveAvailability } from './availability.ts'
 import { measureBubble } from './measure.ts'
 import { buildPrefixSums } from './prefix-sums.ts'
-import { initializeScrollVirtualization } from './scroll.ts'
+import {
+  createResizeObserverManager,
+  type ResizeObserverLike,
+} from './resize.ts'
+import {
+  applyPendingAnchorCorrection,
+  initializeScrollVirtualization,
+} from './scroll.ts'
 import { resolveSelectors } from './selectors.ts'
 import {
   buildBubbleRecords,
@@ -13,6 +20,7 @@ import {
 import { scanTranscript, type TranscriptScanResult } from './transcript-scan.ts'
 
 export interface ContentBootstrapDependencies {
+  createResizeObserver?(callback: ResizeObserverCallback): ResizeObserverLike
   document: Document
   pathname: string
   reportAvailability(message: ReturnType<typeof createReportContentAvailabilityMessage>): void
@@ -43,9 +51,25 @@ export function bootstrapContentScript(
       : null
 
   if (sessionState !== null) {
-    initializeScrollVirtualization(sessionState, {
+    let resizeObserverManager: ReturnType<typeof createResizeObserverManager> | null = null
+    const scrollController = initializeScrollVirtualization(sessionState, {
+      afterPatch() {
+        resizeObserverManager?.refreshObservedRecords()
+      },
       requestAnimationFrame: dependencies.requestAnimationFrame ?? window.requestAnimationFrame.bind(window),
     })
+    resizeObserverManager = createResizeObserverManager(sessionState, {
+      applyPendingCorrection() {
+        applyPendingAnchorCorrection(sessionState)
+      },
+      createResizeObserver:
+        dependencies.createResizeObserver ?? ((callback) => new ResizeObserver(callback)),
+      measure: measureBubble,
+      schedulePatch() {
+        return scrollController.schedulePatch()
+      },
+    })
+    resizeObserverManager.refreshObservedRecords()
   }
 
   dependencies.reportAvailability(createReportContentAvailabilityMessage(availability))

--- a/src/content/resize.ts
+++ b/src/content/resize.ts
@@ -1,0 +1,106 @@
+import { accumulateScrollCorrection } from './anchor.ts'
+import { rebuildPrefixSumsFromIndex } from './prefix-sums.ts'
+import type { TranscriptSessionState } from './state.ts'
+
+const MIN_SIGNIFICANT_HEIGHT_DELTA_PX = 1
+
+export interface ResizeObserverLike {
+  disconnect(): void
+  observe(target: Element): void
+  unobserve(target: Element): void
+}
+
+export interface ResizeObserverManager {
+  disconnect(): void
+  refreshObservedRecords(): void
+}
+
+export interface ResizeObserverManagerDependencies {
+  applyPendingCorrection(): void
+  createResizeObserver(callback: ResizeObserverCallback): ResizeObserverLike
+  measure(node: Element): number
+  schedulePatch(): boolean
+}
+
+export function shouldIgnoreHeightDelta(
+  previousHeight: number,
+  nextHeight: number,
+): boolean {
+  return Math.abs(nextHeight - previousHeight) < MIN_SIGNIFICANT_HEIGHT_DELTA_PX
+}
+
+export function createResizeObserverManager(
+  state: TranscriptSessionState,
+  dependencies: ResizeObserverManagerDependencies,
+): ResizeObserverManager {
+  const observedNodes = new Set<Element>()
+  const recordsByNode = new Map(state.records.map((record) => [record.node, record]))
+  const observer = dependencies.createResizeObserver((entries) => {
+    handleResizeEntries(entries)
+  })
+
+  const refreshObservedRecords = () => {
+    for (const record of state.records) {
+      const isObserved = observedNodes.has(record.node)
+      const shouldObserve = record.mounted && record.node.isConnected
+
+      if (shouldObserve && !isObserved) {
+        observer.observe(record.node)
+        observedNodes.add(record.node)
+      } else if (!shouldObserve && isObserved) {
+        observer.unobserve(record.node)
+        observedNodes.delete(record.node)
+      }
+    }
+  }
+
+  function handleResizeEntries(entries: readonly ResizeObserverEntry[]): void {
+    let hasAcceptedResize = false
+
+    for (const entry of entries) {
+      const record = recordsByNode.get(entry.target)
+
+      if (record === undefined || !record.mounted || !record.node.isConnected) {
+        continue
+      }
+
+      const nextHeight = dependencies.measure(record.node)
+
+      if (shouldIgnoreHeightDelta(record.measuredHeight, nextHeight)) {
+        continue
+      }
+
+      const previousHeight = record.measuredHeight
+      const heightDelta = nextHeight - previousHeight
+
+      record.measuredHeight = nextHeight
+      state.prefixSums = rebuildPrefixSumsFromIndex(state.prefixSums, state.records, record.index)
+      state.pendingScrollCorrection = accumulateScrollCorrection(
+        state.pendingScrollCorrection,
+        state.anchor,
+        record.index,
+        heightDelta,
+      )
+      hasAcceptedResize = true
+    }
+
+    if (!hasAcceptedResize) {
+      return
+    }
+
+    if (dependencies.schedulePatch()) {
+      return
+    }
+
+    dependencies.applyPendingCorrection()
+    dependencies.schedulePatch()
+  }
+
+  return {
+    disconnect() {
+      observedNodes.clear()
+      observer.disconnect()
+    },
+    refreshObservedRecords,
+  }
+}

--- a/src/content/scroll.ts
+++ b/src/content/scroll.ts
@@ -9,34 +9,39 @@ import { patchMountedRange } from './patch.ts'
 import { findRangeByScrollPosition, shouldSchedulePatch } from './range.ts'
 import type { MountedRange, TranscriptSessionState } from './state.ts'
 
+export interface ScrollVirtualizationController {
+  schedulePatch(): boolean
+}
+
 export interface ScrollVirtualizationDependencies {
+  afterPatch?(state: TranscriptSessionState): void
   requestAnimationFrame(callback: FrameRequestCallback): number
 }
 
 export function initializeScrollVirtualization(
   state: TranscriptSessionState,
   dependencies: ScrollVirtualizationDependencies = createDefaultDependencies(),
-): void {
+): ScrollVirtualizationController {
   let patchFrameQueued = false
   let queuedRange: MountedRange | null = null
 
-  const handleScroll = () => {
+  const schedulePatch = () => {
     const nextRange = getMountedRangeForScrollPosition(state)
 
     if (nextRange === null) {
-      return
+      return false
     }
 
     const currentTargetRange = queuedRange ?? state.mountedRange
 
     if (!shouldSchedulePatch(currentTargetRange, nextRange)) {
-      return
+      return false
     }
 
     queuedRange = nextRange
 
     if (patchFrameQueued) {
-      return
+      return true
     }
 
     patchFrameQueued = true
@@ -50,11 +55,16 @@ export function initializeScrollVirtualization(
       const rangeToApply = queuedRange
       queuedRange = null
       applyMountedRangeUpdate(state, rangeToApply)
+      dependencies.afterPatch?.(state)
     })
+
+    return true
   }
 
-  handleScroll()
-  state.scrollContainer.addEventListener('scroll', handleScroll, { passive: true })
+  schedulePatch()
+  state.scrollContainer.addEventListener('scroll', schedulePatch, { passive: true })
+
+  return { schedulePatch }
 }
 
 function createDefaultDependencies(): ScrollVirtualizationDependencies {
@@ -65,7 +75,7 @@ function createDefaultDependencies(): ScrollVirtualizationDependencies {
   }
 }
 
-function getMountedRangeForScrollPosition(
+export function getMountedRangeForScrollPosition(
   state: TranscriptSessionState,
 ): MountedRange | null {
   const viewportHeight = resolveViewportHeight(state.scrollContainer)
@@ -87,11 +97,18 @@ export function applyMountedRangeUpdate(
   const anchor = captureAnchorSnapshot(state.records, viewportRect)
 
   patchMountedRange(state, range.start, range.end)
-
   const correction =
     anchor === null
       ? 0
       : state.pendingScrollCorrection + resolveAnchorCorrection(anchor, viewportRect.top)
+
+  applyScrollCorrection(state.scrollContainer, correction)
+  state.pendingScrollCorrection = 0
+  state.anchor = captureAnchorSnapshot(state.records, resolveViewportRect(state.scrollContainer))
+}
+
+export function applyPendingAnchorCorrection(state: TranscriptSessionState): void {
+  const correction = state.anchor === null ? 0 : state.pendingScrollCorrection
 
   applyScrollCorrection(state.scrollContainer, correction)
   state.pendingScrollCorrection = 0

--- a/tests/integration/content-bootstrap.spec.ts
+++ b/tests/integration/content-bootstrap.spec.ts
@@ -134,9 +134,7 @@ test('스크롤로 mounted range가 바뀌면 다음 frame에서만 패치한다
   await installFixtureRoutes(page)
   await page.goto('http://fixture.test/c/bubble-50?fixture=bubble-50')
 
-  await expect
-    .poll(async () => page.evaluate(() => (window as WindowWithTestState).__rafCallCount))
-    .toBe(1)
+  await expectInitialMountedWindow(page)
 
   await page.evaluate(() => {
     const scrollContainer = document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')
@@ -173,9 +171,7 @@ test('range가 바뀌지 않는 scroll은 추가 frame을 예약하지 않는다
   await installFixtureRoutes(page)
   await page.goto('http://fixture.test/c/bubble-50?fixture=bubble-50')
 
-  await expect
-    .poll(async () => page.evaluate(() => (window as WindowWithTestState).__rafCallCount))
-    .toBe(1)
+  await expectInitialMountedWindow(page)
 
   await page.evaluate(() => {
     const scrollContainer = document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')
@@ -208,6 +204,187 @@ test('range가 바뀌지 않는 scroll은 추가 frame을 예약하지 않는다
   expect(await page.evaluate(() => (window as WindowWithTestState).__rafCallCount)).toBe(2)
 })
 
+test('mounted bubble resize는 prefix sum과 mounted range를 갱신한다', async ({ page }) => {
+  await installFixtureRoutes(page)
+  await page.goto('http://fixture.test/c/bubble-50?fixture=bubble-50')
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const transcriptRoot = document.querySelector('[data-cgpt-transcript-root]')
+        const children = transcriptRoot === null ? [] : Array.from(transcriptRoot.children)
+
+        return {
+          bottomSpacerHeight: children.at(-1)?.getAttribute('style') ?? null,
+          childCount: children.length,
+          lastBubbleText: children.at(-2)?.textContent ?? null,
+          rafCallCount: (window as WindowWithTestState).__rafCallCount,
+        }
+      }),
+    )
+    .toEqual({
+      bottomSpacerHeight: 'height: 4600px;',
+      childCount: 6,
+      lastBubbleText: 'Bubble 3',
+      rafCallCount: 1,
+    })
+
+  await page.evaluate(() => {
+    ;(window as WindowWithTestState).__allBubbles[0]?.setAttribute(
+      'style',
+      'display: block; height: 250px;',
+    )
+  })
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const transcriptRoot = document.querySelector('[data-cgpt-transcript-root]')
+        const children = transcriptRoot === null ? [] : Array.from(transcriptRoot.children)
+
+        return {
+          bottomSpacerHeight: children.at(-1)?.getAttribute('style') ?? null,
+          childCount: children.length,
+          lastBubbleText: children.at(-2)?.textContent ?? null,
+          rafCallCount: (window as WindowWithTestState).__rafCallCount,
+        }
+      }),
+    )
+    .toEqual({
+      bottomSpacerHeight: 'height: 4700px;',
+      childCount: 5,
+      lastBubbleText: 'Bubble 2',
+      rafCallCount: 2,
+    })
+})
+
+test('detached bubble resize는 관찰되지 않는다', async ({ page }) => {
+  await installFixtureRoutes(page)
+  await page.goto('http://fixture.test/c/bubble-50?fixture=bubble-50')
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => ({
+        bottomSpacerHeight:
+          document.querySelector('[data-cgpt-bottom-spacer]')?.getAttribute('style') ?? null,
+        detachedBubbleConnected:
+          (window as WindowWithTestState).__allBubbles[10]?.isConnected ?? null,
+        rafCallCount: (window as WindowWithTestState).__rafCallCount,
+      })),
+    )
+    .toEqual({
+      bottomSpacerHeight: 'height: 4600px;',
+      detachedBubbleConnected: false,
+      rafCallCount: 1,
+    })
+
+  await page.evaluate(async () => {
+    ;(window as WindowWithTestState).__allBubbles[10]?.setAttribute(
+      'style',
+      'display: block; height: 250px;',
+    )
+
+    await new Promise((resolve) => window.setTimeout(resolve, 100))
+  })
+
+  expect(
+    await page.evaluate(() => ({
+      bottomSpacerHeight:
+        document.querySelector('[data-cgpt-bottom-spacer]')?.getAttribute('style') ?? null,
+      rafCallCount: (window as WindowWithTestState).__rafCallCount,
+    })),
+  ).toEqual({
+    bottomSpacerHeight: 'height: 4600px;',
+    rafCallCount: 1,
+  })
+})
+
+test('anchor 위 bubble resize는 읽기 위치를 유지한다', async ({ page }) => {
+  await installFixtureRoutes(page)
+  await page.goto('http://fixture.test/c/bubble-50?fixture=bubble-50')
+
+  await expectInitialMountedWindow(page)
+
+  await page.evaluate(() => {
+    const scrollContainer = document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')
+
+    if (scrollContainer === null) {
+      throw new Error('scroll container fixture is missing')
+    }
+
+    scrollContainer.scrollTop = 250
+    scrollContainer.dispatchEvent(new Event('scroll'))
+  })
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const transcriptRoot = document.querySelector('[data-cgpt-transcript-root]')
+        const children = transcriptRoot === null ? [] : Array.from(transcriptRoot.children)
+
+        return {
+          lastBubbleText: children.at(-2)?.textContent ?? null,
+          rafCallCount: (window as WindowWithTestState).__rafCallCount,
+        }
+      }),
+    )
+    .toEqual({
+      lastBubbleText: 'Bubble 6',
+      rafCallCount: 2,
+    })
+
+  const beforeResize = await page.evaluate(() => {
+    const scrollContainer = document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')
+    const anchorBubble = (window as WindowWithTestState).__allBubbles[2]
+
+    if (scrollContainer === null || anchorBubble === undefined) {
+      throw new Error('anchor fixture is missing')
+    }
+
+    return {
+      anchorOffset:
+        anchorBubble.getBoundingClientRect().top - scrollContainer.getBoundingClientRect().top,
+      scrollTop: scrollContainer.scrollTop,
+    }
+  })
+
+  expect(beforeResize).toEqual({
+    anchorOffset: -50,
+    scrollTop: 250,
+  })
+
+  await page.evaluate(() => {
+    ;(window as WindowWithTestState).__allBubbles[0]?.setAttribute(
+      'style',
+      'display: block; height: 125px;',
+    )
+  })
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const scrollContainer = document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')
+        const anchorBubble = (window as WindowWithTestState).__allBubbles[2]
+
+        if (scrollContainer === null || anchorBubble === undefined) {
+          throw new Error('anchor fixture is missing')
+        }
+
+        return {
+          anchorOffset:
+            anchorBubble.getBoundingClientRect().top - scrollContainer.getBoundingClientRect().top,
+          rafCallCount: (window as WindowWithTestState).__rafCallCount,
+          scrollTop: scrollContainer.scrollTop,
+        }
+      }),
+    )
+    .toEqual({
+      anchorOffset: -50,
+      rafCallCount: 2,
+      scrollTop: 275,
+    })
+})
+
 function renderFixtureHtml(requestPath: string): string {
   const url = new URL(`http://fixture${requestPath}`)
   const fixture = url.searchParams.get('fixture')
@@ -223,6 +400,7 @@ function renderFixtureHtml(requestPath: string): string {
     <script>
       window.__reportedMessages = []
       window.__rafCallCount = 0
+      window.__allBubbles = Array.from(document.querySelectorAll('[data-cgpt-transcript-bubble]'))
       const originalRequestAnimationFrame = window.requestAnimationFrame.bind(window)
       window.requestAnimationFrame = function requestAnimationFrameWrapper(callback) {
         window.__rafCallCount += 1
@@ -342,6 +520,28 @@ async function installFixtureRoutes(page: Page): Promise<void> {
   })
 }
 
+async function expectInitialMountedWindow(page: Page): Promise<void> {
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const transcriptRoot = document.querySelector('[data-cgpt-transcript-root]')
+        const children = transcriptRoot === null ? [] : Array.from(transcriptRoot.children)
+
+        return {
+          firstBubbleText: children[1]?.textContent ?? null,
+          lastBubbleText: children.at(-2)?.textContent ?? null,
+          rafCallCount: (window as WindowWithTestState).__rafCallCount,
+        }
+      }),
+    )
+    .toEqual({
+      firstBubbleText: 'Bubble 0',
+      lastBubbleText: 'Bubble 3',
+      rafCallCount: 1,
+    })
+}
+
 interface WindowWithTestState extends Window {
+  __allBubbles: HTMLElement[]
   __rafCallCount: number
 }

--- a/tests/unit/content-bootstrap.test.ts
+++ b/tests/unit/content-bootstrap.test.ts
@@ -69,6 +69,14 @@ describe('selector resolution', () => {
   })
 })
 
+function createNoopResizeObserver() {
+  return {
+    disconnect() {},
+    observe() {},
+    unobserve() {},
+  }
+}
+
 function makeDocumentWithBubbles(bubbleCount: number): Document {
   const transcriptRoot = document.createElement('section')
   transcriptRoot.setAttribute('data-cgpt-transcript-root', '')
@@ -165,6 +173,7 @@ describe('transcript scan integration', () => {
 
   it('returns scanResult with activationEligible=true for 50 bubbles', () => {
     const result = bootstrapContentScript({
+      createResizeObserver: createNoopResizeObserver,
       document: makeDocumentWithBubbles(50),
       pathname: '/c/example',
       reportAvailability() {},
@@ -182,6 +191,7 @@ describe('transcript scan integration', () => {
     })
 
     const result = bootstrapContentScript({
+      createResizeObserver: createNoopResizeObserver,
       document: fixture.document,
       pathname: '/c/example',
       reportAvailability() {},
@@ -236,6 +246,7 @@ describe('transcript scan integration', () => {
     })
 
     const result = bootstrapContentScript({
+      createResizeObserver: createNoopResizeObserver,
       document: fixture.document,
       pathname: '/c/example',
       reportAvailability() {},

--- a/tests/unit/content-resize.test.ts
+++ b/tests/unit/content-resize.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+
+import { captureAnchorSnapshot } from '../../src/content/anchor.ts'
+import {
+  createResizeObserverManager,
+  shouldIgnoreHeightDelta,
+} from '../../src/content/resize.ts'
+import type { BubbleRecord, TranscriptSessionState } from '../../src/content/state.ts'
+
+describe('shouldIgnoreHeightDelta', () => {
+  it('ignores height drift smaller than 1px', () => {
+    expect(shouldIgnoreHeightDelta(100, 100.99)).toBe(true)
+    expect(shouldIgnoreHeightDelta(100, 99.25)).toBe(true)
+  })
+
+  it('keeps 1px or larger height changes', () => {
+    expect(shouldIgnoreHeightDelta(100, 101)).toBe(false)
+    expect(shouldIgnoreHeightDelta(100, 98.5)).toBe(false)
+  })
+})
+
+describe('createResizeObserverManager', () => {
+  it('observes only mounted records and unobserves detached ones on refresh', () => {
+    const fixture = makeSessionFixture([100, 100, 100])
+    const observe = vi.fn()
+    const unobserve = vi.fn()
+    let callback: ResizeObserverCallback | null = null
+
+    fixture.sessionState.records[0]!.mounted = true
+    fixture.sessionState.records[1]!.mounted = true
+
+    const manager = createResizeObserverManager(fixture.sessionState, {
+      applyPendingCorrection() {},
+      createResizeObserver(nextCallback) {
+        callback = nextCallback
+
+        return {
+          disconnect() {},
+          observe,
+          unobserve,
+        }
+      },
+      measure(node) {
+        return fixture.heights.get(node) ?? 0
+      },
+      schedulePatch() {
+        return false
+      },
+    })
+
+    manager.refreshObservedRecords()
+
+    expect(observe).toHaveBeenCalledTimes(2)
+    expect(observe).toHaveBeenNthCalledWith(1, fixture.bubbles[0])
+    expect(observe).toHaveBeenNthCalledWith(2, fixture.bubbles[1])
+    expect(callback).not.toBeNull()
+
+    fixture.sessionState.records[1]!.mounted = false
+    fixture.transcriptRoot.removeChild(fixture.bubbles[1]!)
+
+    manager.refreshObservedRecords()
+
+    expect(unobserve).toHaveBeenCalledTimes(1)
+    expect(unobserve).toHaveBeenCalledWith(fixture.bubbles[1])
+  })
+
+  it('updates measured height and prefix sums, then applies anchor correction when no patch is queued', () => {
+    const fixture = makeSessionFixture([100, 100, 100, 100, 100], {
+      scrollTop: 250,
+      viewportHeight: 200,
+      viewportTop: 50,
+    })
+    let callback: ResizeObserverCallback | null = null
+
+    for (const record of fixture.sessionState.records) {
+      record.mounted = true
+    }
+
+    fixture.sessionState.mountedRange = { start: 0, end: 4 }
+    fixture.sessionState.anchor = captureAnchorSnapshot(fixture.sessionState.records, {
+      bottom: 250,
+      top: 50,
+    })
+
+    const manager = createResizeObserverManager(fixture.sessionState, {
+      applyPendingCorrection() {
+        fixture.scrollContainer.scrollTop += fixture.sessionState.pendingScrollCorrection
+        fixture.sessionState.pendingScrollCorrection = 0
+        fixture.sessionState.anchor = captureAnchorSnapshot(fixture.sessionState.records, {
+          bottom: 250,
+          top: 50,
+        })
+      },
+      createResizeObserver(nextCallback) {
+        callback = nextCallback
+
+        return {
+          disconnect() {},
+          observe() {},
+          unobserve() {},
+        }
+      },
+      measure(node) {
+        return fixture.heights.get(node) ?? 0
+      },
+      schedulePatch() {
+        return false
+      },
+    })
+
+    manager.refreshObservedRecords()
+    fixture.heights.set(fixture.bubbles[0], 125)
+
+    callback?.(
+      [
+        {
+          target: fixture.bubbles[0],
+        } as ResizeObserverEntry,
+      ],
+      {} as ResizeObserver,
+    )
+
+    expect(fixture.sessionState.records[0]?.measuredHeight).toBe(125)
+    expect(fixture.sessionState.prefixSums).toEqual([125, 225, 325, 425, 525])
+    expect(fixture.scrollContainer.scrollTop).toBe(275)
+    expect(fixture.sessionState.pendingScrollCorrection).toBe(0)
+    expect(fixture.sessionState.anchor?.index).toBe(2)
+  })
+
+  it('queues a patch instead of applying correction immediately when resize changes need a remount check', () => {
+    const fixture = makeSessionFixture([100, 100, 100, 100])
+    let callback: ResizeObserverCallback | null = null
+    const applyPendingCorrection = vi.fn()
+    const schedulePatch = vi.fn(() => true)
+
+    fixture.sessionState.records[0]!.mounted = true
+    fixture.sessionState.records[1]!.mounted = true
+    fixture.sessionState.mountedRange = { start: 0, end: 1 }
+
+    const manager = createResizeObserverManager(fixture.sessionState, {
+      applyPendingCorrection,
+      createResizeObserver(nextCallback) {
+        callback = nextCallback
+
+        return {
+          disconnect() {},
+          observe() {},
+          unobserve() {},
+        }
+      },
+      measure(node) {
+        return fixture.heights.get(node) ?? 0
+      },
+      schedulePatch,
+    })
+
+    manager.refreshObservedRecords()
+    fixture.heights.set(fixture.bubbles[0], 140)
+
+    callback?.(
+      [
+        {
+          target: fixture.bubbles[0],
+        } as ResizeObserverEntry,
+      ],
+      {} as ResizeObserver,
+    )
+
+    expect(schedulePatch).toHaveBeenCalledTimes(1)
+    expect(applyPendingCorrection).not.toHaveBeenCalled()
+  })
+})
+
+function makeSessionFixture(
+  heights: number[],
+  options: {
+    scrollTop?: number
+    viewportHeight?: number
+    viewportTop?: number
+  } = {},
+): {
+  bubbles: HTMLElement[]
+  heights: Map<Element, number>
+  scrollContainer: HTMLElement
+  sessionState: TranscriptSessionState
+  transcriptRoot: HTMLElement
+} {
+  document.body.innerHTML = ''
+
+  const transcriptRoot = document.createElement('section')
+  const scrollContainer = document.createElement('main')
+  const prefixSums = buildPrefixSums(heights)
+  const measuredHeights = new Map<Element, number>()
+  const bubbles = heights.map((height, index) => {
+    const bubble = document.createElement('article')
+    const top = index === 0 ? 0 : (prefixSums[index - 1] ?? 0)
+
+    measuredHeights.set(bubble, height)
+    bubble.textContent = `Bubble ${index}`
+    bubble.getBoundingClientRect = () => {
+      const nextHeight = measuredHeights.get(bubble) ?? height
+      const topOffset = options.viewportTop ?? 0
+
+      return {
+        bottom: topOffset + top - scrollContainer.scrollTop + nextHeight,
+        height: nextHeight,
+        top: topOffset + top - scrollContainer.scrollTop,
+      } as DOMRect
+    }
+    transcriptRoot.append(bubble)
+    return bubble
+  })
+  const records = bubbles.map((bubble, index): BubbleRecord => ({
+    index,
+    measuredHeight: heights[index]!,
+    mounted: false,
+    node: bubble,
+    pinned: false,
+  }))
+
+  Object.defineProperty(scrollContainer, 'clientHeight', {
+    configurable: true,
+    value: options.viewportHeight ?? 200,
+  })
+
+  scrollContainer.scrollTop = options.scrollTop ?? 0
+  scrollContainer.getBoundingClientRect = () =>
+    ({
+      height: options.viewportHeight ?? 200,
+      top: options.viewportTop ?? 0,
+    }) as DOMRect
+
+  scrollContainer.append(transcriptRoot)
+  document.body.append(scrollContainer)
+
+  return {
+    bubbles,
+    heights: measuredHeights,
+    scrollContainer,
+    sessionState: {
+      anchor: null,
+      mountedRange: null,
+      pendingScrollCorrection: 0,
+      prefixSums,
+      records,
+      scrollContainer,
+      transcriptRoot,
+    },
+    transcriptRoot,
+  }
+}
+
+function buildPrefixSums(heights: number[]): number[] {
+  return heights.reduce<number[]>((prefixSums, height) => {
+    const previous = prefixSums[prefixSums.length - 1] ?? 0
+
+    prefixSums.push(previous + height)
+    return prefixSums
+  }, [])
+}

--- a/todo.md
+++ b/todo.md
@@ -188,21 +188,21 @@
 
 ## 9. ResizeObserver integration
 
-- [ ] Add `ResizeObserver` manager
-- [ ] Observe mounted bubbles only
-- [ ] Unobserve detached bubbles
-- [ ] Re-measure resized mounted bubbles
-- [ ] Ignore height deltas `< 1px`
-- [ ] Update BubbleRecord height
-- [ ] Rebuild prefix-sum suffix from changed index
-- [ ] Apply anchor-preserving correction where needed
-- [ ] Schedule patch if range boundaries change
-- [ ] Add integration tests for resize behavior
+- [x] Add `ResizeObserver` manager
+- [x] Observe mounted bubbles only
+- [x] Unobserve detached bubbles
+- [x] Re-measure resized mounted bubbles
+- [x] Ignore height deltas `< 1px`
+- [x] Update BubbleRecord height
+- [x] Rebuild prefix-sum suffix from changed index
+- [x] Apply anchor-preserving correction where needed
+- [x] Schedule patch if range boundaries change
+- [x] Add integration tests for resize behavior
 
 ### Acceptance criteria
-- [ ] Mounted bubble resize updates state
-- [ ] Detached bubbles are not observed
-- [ ] Anchor-preserving correction is applied when appropriate
+- [x] Mounted bubble resize updates state
+- [x] Detached bubbles are not observed
+- [x] Anchor-preserving correction is applied when appropriate
 
 ---
 


### PR DESCRIPTION
## 요약
- mounted bubble만 observe하는 ResizeObserver 관리자를 추가했습니다.
- resize 시 높이 캐시, prefix sum, 앵커 보정을 갱신하고 필요한 경우 mounted range 패치를 다시 예약합니다.
- unit 테스트와 Playwright 시나리오를 보강하고 todo 9번 섹션을 검증 완료 상태로 갱신했습니다.

## 검증
- `pnpm run test`

Closes #12