### PR TITLE
작업 13: dirty rebuild 코디네이터 구현

### DIFF
--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -9,7 +9,11 @@ import { resolveAvailability } from './availability.ts'
 import { measureBubble } from './measure.ts'
 import { clearStreamingPlaceholder } from './placeholder.ts'
 import { buildPrefixSums } from './prefix-sums.ts'
-import { requestDirtyRebuild } from './rebuild.ts'
+import {
+  createStructuralRebuildObserverManager,
+  requestDirtyRebuild,
+  runDirtyRebuild,
+} from './rebuild.ts'
 import {
   createResizeObserverManager,
   type ResizeObserverLike,
@@ -21,6 +25,7 @@ import {
 import { resolveSelectors } from './selectors.ts'
 import {
   buildBubbleRecords,
+  markAllRecordsMounted,
   type TranscriptSessionState,
 } from './state.ts'
 import {
@@ -64,70 +69,141 @@ export function bootstrapContentScript(
       : null
 
   if (sessionState !== null && selectors !== null) {
+    const activeSelectors = selectors
+    const activeSessionState = sessionState
     let appendObserverManager: ReturnType<typeof createAppendObserverManager> | null = null
     let resizeObserverManager: ReturnType<typeof createResizeObserverManager> | null = null
+    let structuralRebuildObserverManager:
+      | ReturnType<typeof createStructuralRebuildObserverManager>
+      | null = null
     let streamingObserverManager: ReturnType<typeof createStreamingObserverManager> | null = null
+    let dirtyRebuildInProgress = false
 
-    sessionState.isStreaming = detectStreamingState(
+    activeSessionState.isStreaming = detectStreamingState(
       dependencies.document,
-      selectors.streamingIndicatorSelector,
+      activeSelectors.streamingIndicatorSelector,
     )
 
-    if (sessionState.isStreaming) {
-      markAllRecordsMounted(sessionState)
+    if (activeSessionState.isStreaming) {
+      markAllRecordsMounted(activeSessionState)
     }
 
-    const scrollController = initializeScrollVirtualization(sessionState, {
+    const scrollController = initializeScrollVirtualization(activeSessionState, {
       afterPatch() {
         appendObserverManager?.flushPendingMutationRecords()
+        structuralRebuildObserverManager?.flushPendingMutationRecords()
         resizeObserverManager?.refreshObservedRecords()
       },
       requestAnimationFrame: dependencies.requestAnimationFrame ?? window.requestAnimationFrame.bind(window),
     })
-    resizeObserverManager = createResizeObserverManager(sessionState, {
-      applyPendingCorrection() {
-        applyPendingAnchorCorrection(sessionState)
-      },
-      createResizeObserver:
-        dependencies.createResizeObserver ?? ((callback) => new ResizeObserver(callback)),
-      measure: measureBubble,
-      schedulePatch() {
-        return scrollController.schedulePatch()
-      },
-    })
-    appendObserverManager = createAppendObserverManager(sessionState, {
-      clearTimeout: dependencies.clearTimeout ?? window.clearTimeout.bind(window),
-      createMutationObserver:
-        dependencies.createMutationObserver ?? ((callback) => new MutationObserver(callback)),
-      isTranscriptBubble(node): node is Element {
-        return node instanceof Element && node.matches(selectors.bubbleSelector)
-      },
-      measure: measureBubble,
-      requestDirtyRebuild,
-      schedulePatch(options) {
-        return scrollController.schedulePatch(options)
-      },
-      setTimeout: dependencies.setTimeout ?? window.setTimeout.bind(window),
-    })
-    streamingObserverManager = createStreamingObserverManager({
-      createMutationObserver:
-        dependencies.createMutationObserver ?? ((callback) => new MutationObserver(callback)),
-      document: dependencies.document,
-      onStreamingChange(nextIsStreaming) {
-        sessionState.isStreaming = nextIsStreaming
 
-        if (nextIsStreaming) {
-          return
-        }
+    const disconnectObservers = () => {
+      appendObserverManager?.disconnect()
+      appendObserverManager = null
+      resizeObserverManager?.disconnect()
+      resizeObserverManager = null
+      structuralRebuildObserverManager?.disconnect()
+      structuralRebuildObserverManager = null
+      streamingObserverManager?.disconnect()
+      streamingObserverManager = null
+    }
 
-        clearStreamingPlaceholder(sessionState)
-        appendObserverManager?.flushPendingAppends()
-        scrollController.schedulePatch({ force: true })
-      },
-      streamingIndicatorSelector: selectors.streamingIndicatorSelector,
-    })
-    resizeObserverManager.refreshObservedRecords()
-    streamingObserverManager.sync()
+    const runPendingDirtyRebuild = () => {
+      if (activeSessionState.dirtyRebuildReason === null || dirtyRebuildInProgress) {
+        return false
+      }
+
+      dirtyRebuildInProgress = true
+
+      try {
+        return runDirtyRebuild(activeSessionState, activeSessionState.dirtyRebuildReason, {
+          detectStreamingState,
+          disconnectObservers,
+          document: dependencies.document,
+          measure: measureBubble,
+          reconnectObservers: connectObservers,
+          resolveSelectors,
+          schedulePatch(options) {
+            return scrollController.schedulePatch(options)
+          },
+        })
+      } finally {
+        dirtyRebuildInProgress = false
+      }
+    }
+
+    const requestDirtyRebuildAndMaybeRun = (
+      state: TranscriptSessionState,
+      reason: Parameters<typeof requestDirtyRebuild>[1],
+    ) => {
+      requestDirtyRebuild(state, reason)
+
+      if (state.isStreaming) {
+        return
+      }
+
+      runPendingDirtyRebuild()
+    }
+
+    function connectObservers(): void {
+      resizeObserverManager = createResizeObserverManager(activeSessionState, {
+        applyPendingCorrection() {
+          applyPendingAnchorCorrection(activeSessionState)
+        },
+        createResizeObserver:
+          dependencies.createResizeObserver ?? ((callback) => new ResizeObserver(callback)),
+        measure: measureBubble,
+        schedulePatch() {
+          return scrollController.schedulePatch()
+        },
+      })
+      appendObserverManager = createAppendObserverManager(activeSessionState, {
+        clearTimeout: dependencies.clearTimeout ?? window.clearTimeout.bind(window),
+        createMutationObserver:
+          dependencies.createMutationObserver ?? ((callback) => new MutationObserver(callback)),
+        isTranscriptBubble(node): node is Element {
+          return node instanceof Element && node.matches(activeSelectors.bubbleSelector)
+        },
+        measure: measureBubble,
+        requestDirtyRebuild: requestDirtyRebuildAndMaybeRun,
+        schedulePatch(options) {
+          return scrollController.schedulePatch(options)
+        },
+        setTimeout: dependencies.setTimeout ?? window.setTimeout.bind(window),
+      })
+      structuralRebuildObserverManager = createStructuralRebuildObserverManager(activeSessionState, {
+        createMutationObserver:
+          dependencies.createMutationObserver ?? ((callback) => new MutationObserver(callback)),
+        requestDirtyRebuild: requestDirtyRebuildAndMaybeRun,
+      })
+      streamingObserverManager = createStreamingObserverManager({
+        createMutationObserver:
+          dependencies.createMutationObserver ?? ((callback) => new MutationObserver(callback)),
+        document: dependencies.document,
+        onStreamingChange(nextIsStreaming) {
+          activeSessionState.isStreaming = nextIsStreaming
+
+          if (nextIsStreaming) {
+            return
+          }
+
+          clearStreamingPlaceholder(activeSessionState)
+
+          if (activeSessionState.dirtyRebuildReason !== null) {
+            runPendingDirtyRebuild()
+            return
+          }
+
+          appendObserverManager?.flushPendingAppends()
+          scrollController.schedulePatch({ force: true })
+        },
+        streamingIndicatorSelector: activeSelectors.streamingIndicatorSelector,
+      })
+      resizeObserverManager.refreshObservedRecords()
+      streamingObserverManager.sync()
+    }
+
+    connectObservers()
   }
 
   dependencies.reportAvailability(createReportContentAvailabilityMessage(availability))
@@ -165,15 +241,4 @@ function createTranscriptSessionState(
     prefixSums: buildPrefixSums(records),
     mountedRange: null,
   }
-}
-
-function markAllRecordsMounted(state: TranscriptSessionState): void {
-  for (const record of state.records) {
-    record.mounted = true
-  }
-
-  state.mountedRange =
-    state.records.length === 0
-      ? null
-      : { start: 0, end: state.records.length - 1 }
 }

--- a/src/content/rebuild.ts
+++ b/src/content/rebuild.ts
@@ -1,14 +1,227 @@
-import type { TranscriptSessionState } from './state.ts'
+import { captureAnchorSnapshot } from './anchor.ts'
+import type { MutationObserverLike } from './append.ts'
+import { buildPrefixSums } from './prefix-sums.ts'
+import type { ResolvedContentSelectors } from './selectors.ts'
+import {
+  buildBubbleRecords,
+  markAllRecordsMounted,
+  type TranscriptSessionState,
+} from './state.ts'
 
 export type DirtyRebuildReason =
   | 'append-existing-node'
   | 'append-non-tail'
   | 'append-removal'
   | 'append-unmatched-node'
+  | 'unsafe-structural-change'
+
+export interface StructuralRebuildObserverManager {
+  disconnect(): void
+  flushPendingMutationRecords(): void
+}
+
+export interface StructuralRebuildObserverManagerDependencies {
+  createMutationObserver(callback: MutationCallback): MutationObserverLike
+  requestDirtyRebuild(state: TranscriptSessionState, reason: DirtyRebuildReason): void
+}
+
+export interface RunDirtyRebuildDependencies {
+  detectStreamingState(document: Document, streamingIndicatorSelector: string): boolean
+  disconnectObservers(): void
+  document: Document
+  measure(node: Element): number
+  reconnectObservers(): void
+  resolveSelectors(document: Document): ResolvedContentSelectors | null
+  schedulePatch(options?: { force?: boolean }): boolean
+}
 
 export function requestDirtyRebuild(
   state: TranscriptSessionState,
   reason: DirtyRebuildReason,
 ): void {
   state.dirtyRebuildReason = reason
+}
+
+export function createStructuralRebuildObserverManager(
+  state: TranscriptSessionState,
+  dependencies: StructuralRebuildObserverManagerDependencies,
+): StructuralRebuildObserverManager {
+  const observer = dependencies.createMutationObserver((mutations) => {
+    if (state.isStreaming || !shouldTriggerStructuralRebuild(state, mutations)) {
+      return
+    }
+
+    dependencies.requestDirtyRebuild(state, 'unsafe-structural-change')
+  })
+
+  observer.observe(state.transcriptRoot, {
+    characterData: true,
+    childList: true,
+    subtree: true,
+  })
+
+  return {
+    disconnect() {
+      observer.disconnect()
+    },
+    flushPendingMutationRecords() {
+      observer.takeRecords()
+    },
+  }
+}
+
+export function runDirtyRebuild(
+  state: TranscriptSessionState,
+  reason: DirtyRebuildReason,
+  dependencies: RunDirtyRebuildDependencies,
+): boolean {
+  state.dirtyRebuildReason = reason
+
+  const rebuildAnchor = state.anchor ?? captureRebuildAnchor(state)
+  const fallbackScrollTop = state.scrollContainer.scrollTop
+
+  dependencies.disconnectObservers()
+
+  const selectors = dependencies.resolveSelectors(dependencies.document)
+
+  if (selectors === null) {
+    dependencies.reconnectObservers()
+    return false
+  }
+
+  const rebuiltNodes = rehydrateTranscriptRoot(state, selectors)
+
+  state.transcriptRoot = selectors.transcriptRoot
+  state.scrollContainer = selectors.scrollContainer
+  state.records = buildBubbleRecords(rebuiltNodes, dependencies.measure)
+  state.prefixSums = buildPrefixSums(state.records)
+  state.mountedRange = null
+  state.pendingScrollCorrection = 0
+  state.anchor = null
+  state.isStreaming = dependencies.detectStreamingState(
+    dependencies.document,
+    selectors.streamingIndicatorSelector,
+  )
+
+  if (state.isStreaming) {
+    markAllRecordsMounted(state)
+  }
+
+  restoreScrollAfterRebuild(state, rebuildAnchor, fallbackScrollTop)
+  state.dirtyRebuildReason = null
+
+  dependencies.reconnectObservers()
+
+  if (!state.isStreaming) {
+    dependencies.schedulePatch({ force: true })
+  }
+
+  return true
+}
+
+function captureRebuildAnchor(
+  state: TranscriptSessionState,
+) {
+  const viewportRect = state.scrollContainer.getBoundingClientRect()
+
+  return captureAnchorSnapshot(state.records, {
+    bottom: viewportRect.top + resolveViewportHeight(state.scrollContainer),
+    top: viewportRect.top,
+  })
+}
+
+function rehydrateTranscriptRoot(
+  state: TranscriptSessionState,
+  selectors: ResolvedContentSelectors,
+): Element[] {
+  const liveBubbles = Array.from(
+    selectors.transcriptRoot.querySelectorAll(selectors.bubbleSelector),
+  )
+  const prefixNodes =
+    state.mountedRange === null
+      ? []
+      : state.records.slice(0, state.mountedRange.start).map((record) => record.node)
+  const suffixNodes =
+    state.mountedRange === null
+      ? []
+      : state.records.slice(state.mountedRange.end + 1).map((record) => record.node)
+  const rebuiltNodes = [...prefixNodes, ...liveBubbles, ...suffixNodes]
+
+  selectors.transcriptRoot.replaceChildren(...rebuiltNodes)
+
+  return rebuiltNodes
+}
+
+function restoreScrollAfterRebuild(
+  state: TranscriptSessionState,
+  rebuildAnchor: ReturnType<typeof captureRebuildAnchor>,
+  fallbackScrollTop: number,
+): void {
+  if (rebuildAnchor === null) {
+    state.scrollContainer.scrollTop = fallbackScrollTop
+    return
+  }
+
+  const anchorIndex = state.records.findIndex((record) => record.node === rebuildAnchor.node)
+
+  if (anchorIndex === -1) {
+    state.scrollContainer.scrollTop = fallbackScrollTop
+    return
+  }
+
+  const heightAboveAnchor = anchorIndex === 0 ? 0 : (state.prefixSums[anchorIndex - 1] ?? 0)
+
+  state.scrollContainer.scrollTop = Math.max(0, heightAboveAnchor - rebuildAnchor.offset)
+}
+
+function shouldTriggerStructuralRebuild(
+  state: TranscriptSessionState,
+  mutations: readonly MutationRecord[],
+): boolean {
+  for (const mutation of mutations) {
+    if (mutation.type === 'characterData') {
+      if (isInternalVirtualizerNode(mutation.target)) {
+        continue
+      }
+
+      return true
+    }
+
+    if (mutation.type !== 'childList') {
+      continue
+    }
+
+    if (mutation.target === state.transcriptRoot) {
+      continue
+    }
+
+    if (isInternalVirtualizerNode(mutation.target)) {
+      continue
+    }
+
+    return true
+  }
+
+  return false
+}
+
+function isInternalVirtualizerNode(node: Node): boolean {
+  const element =
+    node instanceof Element
+      ? node
+      : node.parentElement
+
+  if (element === null) {
+    return false
+  }
+
+  return (
+    element.closest('[data-cgpt-top-spacer]') !== null ||
+    element.closest('[data-cgpt-bottom-spacer]') !== null ||
+    element.closest('[data-cgpt-streaming-gap-placeholder]') !== null
+  )
+}
+
+function resolveViewportHeight(scrollContainer: HTMLElement): number {
+  return scrollContainer.clientHeight || scrollContainer.getBoundingClientRect().height
 }

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -38,3 +38,14 @@ export function buildBubbleRecords(
     pinned: false,
   }))
 }
+
+export function markAllRecordsMounted(state: TranscriptSessionState): void {
+  for (const record of state.records) {
+    record.mounted = true
+  }
+
+  state.mountedRange =
+    state.records.length === 0
+      ? null
+      : { start: 0, end: state.records.length - 1 }
+}

--- a/tests/integration/content-bootstrap.spec.ts
+++ b/tests/integration/content-bootstrap.spec.ts
@@ -789,6 +789,204 @@ test('non-near-bottom append burst는 detached tail로 남는다', async ({ page
     })
 })
 
+test('mid-list removal은 dirty rebuild를 트리거하고 surviving anchor 위치를 복원한다', async ({ page }) => {
+  await installFixtureRoutes(page)
+  await page.goto('http://fixture.test/c/bubble-50?fixture=bubble-50')
+
+  await expectInitialMountedWindow(page)
+  await scrollToTranscriptPosition(page, 400, {
+    firstBubbleText: 'Bubble 2',
+    lastBubbleText: 'Bubble 7',
+    rafCallCount: 2,
+  })
+
+  expect(
+    await page.evaluate(() => {
+      const scrollContainer = document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')
+      const anchorBubble = (window as WindowWithTestState).__allBubbles[4]
+
+      if (scrollContainer === null || anchorBubble === undefined) {
+        throw new Error('dirty rebuild anchor fixture is missing')
+      }
+
+      return {
+        anchorOffset:
+          anchorBubble.getBoundingClientRect().top - scrollContainer.getBoundingClientRect().top,
+        scrollTop: scrollContainer.scrollTop,
+      }
+    }),
+  ).toEqual({
+    anchorOffset: 0,
+    scrollTop: 400,
+  })
+
+  await page.evaluate(() => {
+    const transcriptRoot = document.querySelector<HTMLElement>('[data-cgpt-transcript-root]')
+    const removedBubble = (window as WindowWithTestState).__allBubbles[3]
+
+    if (transcriptRoot === null || removedBubble === undefined) {
+      throw new Error('dirty rebuild removal fixture is missing')
+    }
+
+    transcriptRoot.removeChild(removedBubble)
+  })
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const scrollContainer = document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')
+        const transcriptRoot = document.querySelector('[data-cgpt-transcript-root]')
+        const anchorBubble = (window as WindowWithTestState).__allBubbles[4]
+        const removedBubble = (window as WindowWithTestState).__allBubbles[3]
+        const children = transcriptRoot === null ? [] : Array.from(transcriptRoot.children)
+
+        if (scrollContainer === null || anchorBubble === undefined) {
+          throw new Error('dirty rebuild anchor fixture is missing')
+        }
+
+        return {
+          anchorOffset:
+            anchorBubble.getBoundingClientRect().top - scrollContainer.getBoundingClientRect().top,
+          childCount: children.length,
+          firstBubbleText: children[1]?.textContent ?? null,
+          lastBubbleText: children.at(-2)?.textContent ?? null,
+          removedConnected: removedBubble?.isConnected ?? null,
+          scrollTop: scrollContainer.scrollTop,
+        }
+      }),
+    )
+    .toEqual({
+      anchorOffset: 0,
+      childCount: 8,
+      firstBubbleText: 'Bubble 1',
+      lastBubbleText: 'Bubble 7',
+      removedConnected: false,
+      scrollTop: 300,
+    })
+})
+
+test('anchor bubble가 사라지면 dirty rebuild는 raw scrollTop fallback을 사용한다', async ({ page }) => {
+  await installFixtureRoutes(page)
+  await page.goto('http://fixture.test/c/bubble-50?fixture=bubble-50')
+
+  await expectInitialMountedWindow(page)
+  await scrollToTranscriptPosition(page, 400, {
+    firstBubbleText: 'Bubble 2',
+    lastBubbleText: 'Bubble 7',
+    rafCallCount: 2,
+  })
+
+  await page.evaluate(() => {
+    const transcriptRoot = document.querySelector<HTMLElement>('[data-cgpt-transcript-root]')
+    const removedAnchor = (window as WindowWithTestState).__allBubbles[4]
+
+    if (transcriptRoot === null || removedAnchor === undefined) {
+      throw new Error('dirty rebuild fallback fixture is missing')
+    }
+
+    transcriptRoot.removeChild(removedAnchor)
+  })
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const scrollContainer = document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')
+        const transcriptRoot = document.querySelector('[data-cgpt-transcript-root]')
+        const removedAnchor = (window as WindowWithTestState).__allBubbles[4]
+        const children = transcriptRoot === null ? [] : Array.from(transcriptRoot.children)
+
+        if (scrollContainer === null) {
+          throw new Error('dirty rebuild fallback fixture is missing')
+        }
+
+        return {
+          childCount: children.length,
+          firstBubbleText: children[1]?.textContent ?? null,
+          removedConnected: removedAnchor?.isConnected ?? null,
+          scrollTop: scrollContainer.scrollTop,
+        }
+      }),
+    )
+    .toEqual({
+      childCount: 8,
+      firstBubbleText: 'Bubble 2',
+      removedConnected: false,
+      scrollTop: 400,
+    })
+})
+
+test('dirty rebuild 뒤에도 append observer가 다시 연결된다', async ({ page }) => {
+  await installFixtureRoutes(page)
+  await page.goto('http://fixture.test/c/bubble-50?fixture=bubble-50')
+
+  await expectInitialMountedWindow(page)
+  await scrollToTranscriptPosition(page, 400, {
+    firstBubbleText: 'Bubble 2',
+    lastBubbleText: 'Bubble 7',
+    rafCallCount: 2,
+  })
+
+  await page.evaluate(() => {
+    const transcriptRoot = document.querySelector<HTMLElement>('[data-cgpt-transcript-root]')
+    const removedBubble = (window as WindowWithTestState).__allBubbles[3]
+
+    if (transcriptRoot === null || removedBubble === undefined) {
+      throw new Error('dirty rebuild append fixture is missing')
+    }
+
+    transcriptRoot.removeChild(removedBubble)
+  })
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => ({
+        scrollTop:
+          document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')?.scrollTop ?? null,
+      })),
+    )
+    .toEqual({
+      scrollTop: 300,
+    })
+
+  await page.evaluate(async () => {
+    const transcriptRoot = document.querySelector<HTMLElement>('[data-cgpt-transcript-root]')
+
+    if (transcriptRoot === null) {
+      throw new Error('dirty rebuild append fixture is missing')
+    }
+
+    const appendedBubble = document.createElement('article')
+    appendedBubble.setAttribute('data-cgpt-transcript-bubble', '')
+    appendedBubble.setAttribute('style', 'display: block; height: 100px;')
+    appendedBubble.textContent = 'Bubble 50'
+
+    ;(window as WindowWithTestState).__tailAppendNodes = [appendedBubble]
+
+    transcriptRoot.append(appendedBubble)
+    await new Promise((resolve) => window.setTimeout(resolve, 200))
+  })
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const transcriptRoot = document.querySelector('[data-cgpt-transcript-root]')
+        const children = transcriptRoot === null ? [] : Array.from(transcriptRoot.children)
+
+        return {
+          bottomSpacerHeight: children.at(-1)?.getAttribute('style') ?? null,
+          childCount: children.length,
+          detachedTailBubbleCount:
+            (window as WindowWithTestState).__tailAppendNodes.filter((node) => !node.isConnected).length,
+        }
+      }),
+    )
+    .toEqual({
+      bottomSpacerHeight: 'height: 4300px;',
+      childCount: 8,
+      detachedTailBubbleCount: 1,
+    })
+})
+
 function renderFixtureHtml(requestPath: string): string {
   const url = new URL(`http://fixture${requestPath}`)
   const fixture = url.searchParams.get('fixture')
@@ -943,6 +1141,42 @@ async function expectInitialMountedWindow(page: Page): Promise<void> {
       lastBubbleText: 'Bubble 3',
       rafCallCount: 1,
     })
+}
+
+async function scrollToTranscriptPosition(
+  page: Page,
+  scrollTop: number,
+  expectedWindow: {
+    firstBubbleText: string
+    lastBubbleText: string
+    rafCallCount: number
+  },
+): Promise<void> {
+  await page.evaluate((nextScrollTop) => {
+    const scrollContainer = document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')
+
+    if (scrollContainer === null) {
+      throw new Error('scroll container fixture is missing')
+    }
+
+    scrollContainer.scrollTop = nextScrollTop
+    scrollContainer.dispatchEvent(new Event('scroll'))
+  }, scrollTop)
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const transcriptRoot = document.querySelector('[data-cgpt-transcript-root]')
+        const children = transcriptRoot === null ? [] : Array.from(transcriptRoot.children)
+
+        return {
+          firstBubbleText: children[1]?.textContent ?? null,
+          lastBubbleText: children.at(-2)?.textContent ?? null,
+          rafCallCount: (window as WindowWithTestState).__rafCallCount,
+        }
+      }),
+    )
+    .toEqual(expectedWindow)
 }
 
 interface WindowWithTestState extends Window {

--- a/tests/unit/content-rebuild.test.ts
+++ b/tests/unit/content-rebuild.test.ts
@@ -1,0 +1,323 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createStructuralRebuildObserverManager,
+  runDirtyRebuild,
+} from '../../src/content/rebuild.ts'
+import type { MutationObserverLike } from '../../src/content/append.ts'
+import type { BubbleRecord, TranscriptSessionState } from '../../src/content/state.ts'
+
+describe('runDirtyRebuild', () => {
+  it('rehydrates detached records around the live mounted DOM and restores scrollTop from a surviving anchor', () => {
+    const fixture = makeDirtyRebuildFixture()
+    const disconnectObservers = vi.fn()
+    const reconnectObservers = vi.fn()
+    const schedulePatch = vi.fn(() => true)
+
+    fixture.sessionState.anchor = {
+      index: 4,
+      node: fixture.bubbles[4]!,
+      offset: 0,
+    }
+    fixture.bubbles[4]!.getBoundingClientRect = () =>
+      makeDomRect({
+        bottom: 0,
+        left: 0,
+        right: 100,
+        top: -100,
+      })
+    fixture.transcriptRoot.removeChild(fixture.bubbles[3]!)
+
+    const didRebuild = runDirtyRebuild(fixture.sessionState, 'append-removal', {
+      bubbleSelector: '[data-cgpt-transcript-bubble]',
+      detectStreamingState() {
+        return false
+      },
+      disconnectObservers,
+      document,
+      measure(node) {
+        return fixture.measuredHeights.get(node) ?? 0
+      },
+      reconnectObservers,
+      resolveSelectors() {
+        return {
+          bubbleSelector: '[data-cgpt-transcript-bubble]',
+          scrollContainer: fixture.scrollContainer,
+          streamingIndicatorSelector: '[data-cgpt-streaming-indicator]',
+          transcriptRoot: fixture.transcriptRoot,
+        }
+      },
+      schedulePatch,
+      streamingIndicatorSelector: '[data-cgpt-streaming-indicator]',
+    })
+
+    expect(didRebuild).toBe(true)
+    expect(disconnectObservers).toHaveBeenCalledTimes(1)
+    expect(reconnectObservers).toHaveBeenCalledTimes(1)
+    expect(schedulePatch).toHaveBeenCalledWith({ force: true })
+    expect(fixture.scrollContainer.scrollTop).toBe(300)
+    expect(fixture.sessionState.records.map((record) => record.node.textContent)).toEqual([
+      'Bubble 0',
+      'Bubble 1',
+      'Bubble 2',
+      'Bubble 4',
+      'Bubble 5',
+    ])
+    expect(fixture.sessionState.prefixSums).toEqual([100, 200, 300, 400, 500])
+    expect(fixture.sessionState.dirtyRebuildReason).toBeNull()
+  })
+
+  it('falls back to raw scrollTop when the anchor bubble no longer survives', () => {
+    const fixture = makeDirtyRebuildFixture()
+    const schedulePatch = vi.fn(() => true)
+
+    fixture.transcriptRoot.removeChild(fixture.bubbles[4]!)
+
+    const didRebuild = runDirtyRebuild(fixture.sessionState, 'append-removal', {
+      bubbleSelector: '[data-cgpt-transcript-bubble]',
+      detectStreamingState() {
+        return false
+      },
+      disconnectObservers() {},
+      document,
+      measure(node) {
+        return fixture.measuredHeights.get(node) ?? 0
+      },
+      reconnectObservers() {},
+      resolveSelectors() {
+        return {
+          bubbleSelector: '[data-cgpt-transcript-bubble]',
+          scrollContainer: fixture.scrollContainer,
+          streamingIndicatorSelector: '[data-cgpt-streaming-indicator]',
+          transcriptRoot: fixture.transcriptRoot,
+        }
+      },
+      schedulePatch,
+      streamingIndicatorSelector: '[data-cgpt-streaming-indicator]',
+    })
+
+    expect(didRebuild).toBe(true)
+    expect(schedulePatch).toHaveBeenCalledWith({ force: true })
+    expect(fixture.scrollContainer.scrollTop).toBe(400)
+    expect(fixture.sessionState.records.map((record) => record.node.textContent)).toEqual([
+      'Bubble 0',
+      'Bubble 1',
+      'Bubble 2',
+      'Bubble 3',
+      'Bubble 5',
+    ])
+  })
+})
+
+describe('createStructuralRebuildObserverManager', () => {
+  it('requests a dirty rebuild for unsafe subtree childList mutations', () => {
+    const fixture = makeDirtyRebuildFixture()
+    let callback: MutationCallback | null = null
+    const requestDirtyRebuild = vi.fn()
+
+    createStructuralRebuildObserverManager(fixture.sessionState, {
+      createMutationObserver(nextCallback) {
+        callback = nextCallback
+        return createNoopMutationObserver()
+      },
+      requestDirtyRebuild,
+    })
+
+    const nestedNode = document.createElement('span')
+    fixture.bubbles[4]?.append(nestedNode)
+    callback?.(
+      [makeChildListMutationRecord(fixture.bubbles[4]!, [nestedNode])],
+      {} as MutationObserver,
+    )
+
+    expect(requestDirtyRebuild).toHaveBeenCalledWith(
+      fixture.sessionState,
+      'unsafe-structural-change',
+    )
+  })
+
+  it('requests a dirty rebuild for unsafe subtree characterData mutations', () => {
+    const fixture = makeDirtyRebuildFixture()
+    let callback: MutationCallback | null = null
+    const requestDirtyRebuild = vi.fn()
+    const textNode = document.createTextNode('before')
+
+    fixture.bubbles[4]?.append(textNode)
+
+    createStructuralRebuildObserverManager(fixture.sessionState, {
+      createMutationObserver(nextCallback) {
+        callback = nextCallback
+        return createNoopMutationObserver()
+      },
+      requestDirtyRebuild,
+    })
+
+    textNode.data = 'after'
+    callback?.(
+      [makeCharacterDataMutationRecord(textNode)],
+      {} as MutationObserver,
+    )
+
+    expect(requestDirtyRebuild).toHaveBeenCalledWith(
+      fixture.sessionState,
+      'unsafe-structural-change',
+    )
+  })
+})
+
+function makeDirtyRebuildFixture(): {
+  bubbles: HTMLElement[]
+  measuredHeights: Map<Element, number>
+  scrollContainer: HTMLElement
+  sessionState: TranscriptSessionState
+  transcriptRoot: HTMLElement
+} {
+  document.body.innerHTML = ''
+
+  const scrollContainer = document.createElement('main')
+  const transcriptRoot = document.createElement('section')
+  const streamingIndicator = document.createElement('div')
+  const measuredHeights = new Map<Element, number>()
+  const bubbles = Array.from({ length: 6 }, (_, index) => {
+    const bubble = createBubble(`Bubble ${index}`)
+    measuredHeights.set(bubble, 100)
+    return bubble
+  })
+
+  const topSpacer = document.createElement('div')
+  topSpacer.setAttribute('data-cgpt-top-spacer', '')
+  const bottomSpacer = document.createElement('div')
+  bottomSpacer.setAttribute('data-cgpt-bottom-spacer', '')
+
+  transcriptRoot.append(topSpacer, bubbles[3]!, bubbles[4]!, bubbles[5]!, bottomSpacer)
+  scrollContainer.append(transcriptRoot, streamingIndicator)
+  scrollContainer.scrollTop = 400
+  document.body.append(scrollContainer)
+
+  Object.defineProperty(scrollContainer, 'clientHeight', {
+    configurable: true,
+    value: 200,
+  })
+  scrollContainer.getBoundingClientRect = () =>
+    makeDomRect({
+      bottom: 200,
+      left: 0,
+      right: 100,
+      top: 0,
+    })
+
+  bubbles[3]!.getBoundingClientRect = () =>
+    makeDomRect({
+      bottom: 0,
+      left: 0,
+      right: 100,
+      top: -100,
+    })
+  bubbles[4]!.getBoundingClientRect = () =>
+    makeDomRect({
+      bottom: 100,
+      left: 0,
+      right: 100,
+      top: 0,
+    })
+  bubbles[5]!.getBoundingClientRect = () =>
+    makeDomRect({
+      bottom: 200,
+      left: 0,
+      right: 100,
+      top: 100,
+    })
+
+  const records = bubbles.map((bubble, index): BubbleRecord => ({
+    index,
+    measuredHeight: 100,
+    mounted: index >= 3,
+    node: bubble,
+    pinned: false,
+  }))
+
+  return {
+    bubbles,
+    measuredHeights,
+    scrollContainer,
+    sessionState: {
+      anchor: null,
+      dirtyRebuildReason: null,
+      isStreaming: false,
+      mountedRange: { end: 5, start: 3 },
+      pendingScrollCorrection: 0,
+      prefixSums: [100, 200, 300, 400, 500, 600],
+      records,
+      scrollContainer,
+      transcriptRoot,
+    },
+    transcriptRoot,
+  }
+}
+
+function createBubble(label: string): HTMLElement {
+  const bubble = document.createElement('article')
+
+  bubble.setAttribute('data-cgpt-transcript-bubble', '')
+  bubble.textContent = label
+
+  return bubble
+}
+
+function createNoopMutationObserver(): MutationObserverLike {
+  return {
+    disconnect() {},
+    observe() {},
+    takeRecords() {
+      return []
+    },
+  }
+}
+
+function makeChildListMutationRecord(
+  target: Node,
+  addedNodes: Node[],
+  removedNodes: Node[] = [],
+): MutationRecord {
+  return {
+    addedNodes: addedNodes as unknown as NodeList,
+    attributeName: null,
+    attributeNamespace: null,
+    nextSibling: null,
+    oldValue: null,
+    previousSibling: null,
+    removedNodes: removedNodes as unknown as NodeList,
+    target,
+    type: 'childList',
+  } as MutationRecord
+}
+
+function makeCharacterDataMutationRecord(target: CharacterData): MutationRecord {
+  return {
+    addedNodes: [] as unknown as NodeList,
+    attributeName: null,
+    attributeNamespace: null,
+    nextSibling: null,
+    oldValue: 'before',
+    previousSibling: null,
+    removedNodes: [] as unknown as NodeList,
+    target,
+    type: 'characterData',
+  } as MutationRecord
+}
+
+function makeDomRect(
+  rect: Pick<DOMRect, 'bottom' | 'left' | 'right' | 'top'>,
+): DOMRect {
+  return {
+    ...rect,
+    height: rect.bottom - rect.top,
+    toJSON() {
+      return this
+    },
+    width: rect.right - rect.left,
+    x: rect.left,
+    y: rect.top,
+  } as DOMRect
+}

--- a/todo.md
+++ b/todo.md
@@ -271,29 +271,29 @@
 
 ## 13. Dirty rebuild coordinator
 
-- [ ] Implement full rebuild coordinator
-- [ ] Trigger rebuild for:
-  - [ ] mid-thread edits
-  - [ ] rewrite/regenerate flows
-  - [ ] invalid append validation
-  - [ ] unsafe structural transcript changes
-- [ ] Rebuild flow must:
-  - [ ] capture anchor if possible
-  - [ ] disconnect observers
-  - [ ] discard detached cache
-  - [ ] discard BubbleRecords and measurements
-  - [ ] rescan live transcript DOM
-  - [ ] remeasure all bubbles
-  - [ ] rebuild prefix sums
-  - [ ] restore scroll via surviving anchor node when possible
-  - [ ] otherwise fall back to raw `scrollTop`
-  - [ ] recreate observers
-- [ ] Add integration tests for rebuild scenarios
+- [x] Implement full rebuild coordinator
+- [x] Trigger rebuild for:
+  - [x] mid-thread edits
+  - [x] rewrite/regenerate flows
+  - [x] invalid append validation
+  - [x] unsafe structural transcript changes
+- [x] Rebuild flow must:
+  - [x] capture anchor if possible
+  - [x] disconnect observers
+  - [x] discard detached cache
+  - [x] discard BubbleRecords and measurements
+  - [x] rescan live transcript DOM
+  - [x] remeasure all bubbles
+  - [x] rebuild prefix sums
+  - [x] restore scroll via surviving anchor node when possible
+  - [x] otherwise fall back to raw `scrollTop`
+  - [x] recreate observers
+- [x] Add integration tests for rebuild scenarios
 
 ### Acceptance criteria
-- [ ] Dirty rebuild restores a valid transcript session
-- [ ] Surviving anchor restores position when possible
-- [ ] Fallback to raw `scrollTop` works safely
+- [x] Dirty rebuild restores a valid transcript session
+- [x] Surviving anchor restores position when possible
+- [x] Fallback to raw `scrollTop` works safely
 
 ---
 


### PR DESCRIPTION
## 요약
- dirty rebuild 코디네이터와 구조 변경 감지 observer를 추가했습니다
- observer 연결/해제 수명을 bootstrap에서 관리하고 스트리밍 종료 후 rebuild handoff를 정리했습니다
- dirty rebuild 통합/단위 테스트를 추가하고 `todo.md` 13번 섹션을 검증 결과에 맞게 갱신했습니다

## 검증
- `pnpm exec vitest run tests/unit/content-rebuild.test.ts tests/unit/content-bootstrap.test.ts tests/unit/content-append.test.ts tests/unit/content-scroll.test.ts tests/unit/content-resize.test.ts`
- `pnpm exec playwright test tests/integration/content-bootstrap.spec.ts`
- `pnpm run test`

Closes #16
