### PR TITLE
작업 16: 메모리 가드 구현

### DIFF
--- a/src/background/content-controller.ts
+++ b/src/background/content-controller.ts
@@ -1,14 +1,44 @@
-import type { ContentToWorkerMessage } from '../shared/messages.ts'
+import {
+  createTabEnabledMessage,
+  DISABLE_TAB_VIRTUALIZATION_MESSAGE_TYPE,
+  GET_TAB_ENABLED_MESSAGE_TYPE,
+  REPORT_CONTENT_AVAILABILITY_MESSAGE_TYPE,
+  type ContentToWorkerMessage,
+  type WorkerToContentMessage,
+} from '../shared/messages.ts'
 import type { TabStateStore } from './tab-state.ts'
+
+export interface ContentControllerDependencies {
+  refreshTab(tabId: number): Promise<void>
+  tabStateStore: TabStateStore
+}
 
 export function handleContentMessage(
   message: ContentToWorkerMessage,
   senderTabId: number | null,
-  tabStateStore: TabStateStore,
-): void {
-  if (typeof senderTabId !== 'number') {
-    return
+  dependencies: ContentControllerDependencies,
+): Promise<WorkerToContentMessage | null> {
+  if (message.type === REPORT_CONTENT_AVAILABILITY_MESSAGE_TYPE) {
+    if (typeof senderTabId === 'number') {
+      dependencies.tabStateStore.setTabAvailability(senderTabId, message.availability)
+    }
+
+    return Promise.resolve(null)
   }
 
-  tabStateStore.setTabAvailability(senderTabId, message.availability)
+  if (message.type === GET_TAB_ENABLED_MESSAGE_TYPE) {
+    return Promise.resolve(
+      createTabEnabledMessage(
+        typeof senderTabId === 'number' && dependencies.tabStateStore.getTabPreference(senderTabId),
+      ),
+    )
+  }
+
+  if (message.type !== DISABLE_TAB_VIRTUALIZATION_MESSAGE_TYPE || typeof senderTabId !== 'number') {
+    return Promise.resolve(null)
+  }
+
+  dependencies.tabStateStore.setTabPreference(senderTabId, false)
+
+  return dependencies.refreshTab(senderTabId).then(() => null)
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,3 +1,3 @@
-import { startContentRuntime } from './content/navigation.ts'
+import { bootstrapContentEntry } from './content/startup.ts'
 
-void startContentRuntime()
+void bootstrapContentEntry()

--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -21,9 +21,16 @@ import {
   reportUnavailableStatus,
 } from './failure.ts'
 import {
+  DEFAULT_MEMORY_GUARD_THRESHOLD,
+  estimateDetachedCachePressure,
+  shouldDisableVirtualizationForMemory,
+  type MemoryGuardThreshold,
+} from './memory-guard.ts'
+import {
   createResizeObserverManager,
   type ResizeObserverLike,
 } from './resize.ts'
+import { disableCurrentTabVirtualization } from './runtime-control.ts'
 import {
   applyPendingAnchorCorrection,
   initializeScrollVirtualization,
@@ -44,7 +51,9 @@ export interface ContentBootstrapDependencies {
   clearTimeout?(handle: number): void
   createMutationObserver?(callback: MutationCallback): MutationObserverLike
   createResizeObserver?(callback: ResizeObserverCallback): ResizeObserverLike
+  disableVirtualizationForMemoryGuard?(): Promise<void> | void
   document: Document
+  memoryGuardThreshold?: MemoryGuardThreshold
   pathname: string
   reportAvailability(message: ReturnType<typeof createReportContentAvailabilityMessage>): void
   requestAnimationFrame?(callback: FrameRequestCallback): number
@@ -100,6 +109,9 @@ export function bootstrapContentScript(
     let streamingObserverManager: ReturnType<typeof createStreamingObserverManager> | null = null
     let dirtyRebuildInProgress = false
     let sessionClosed = false
+    let scrollController: ReturnType<typeof initializeScrollVirtualization> | null = null
+    const memoryGuardThreshold =
+      dependencies.memoryGuardThreshold ?? DEFAULT_MEMORY_GUARD_THRESHOLD
 
     activeSessionState.isStreaming = detectStreamingState(
       dependencies.document,
@@ -109,15 +121,6 @@ export function bootstrapContentScript(
     if (activeSessionState.isStreaming) {
       markAllRecordsMounted(activeSessionState)
     }
-
-    const scrollController = initializeScrollVirtualization(activeSessionState, {
-      afterPatch() {
-        appendObserverManager?.flushPendingMutationRecords()
-        structuralRebuildObserverManager?.flushPendingMutationRecords()
-        resizeObserverManager?.refreshObservedRecords()
-      },
-      requestAnimationFrame: dependencies.requestAnimationFrame ?? window.requestAnimationFrame.bind(window),
-    })
 
     const disconnectObservers = () => {
       appendObserverManager?.disconnect()
@@ -139,7 +142,8 @@ export function bootstrapContentScript(
 
       sessionClosed = true
       disconnectObservers()
-      scrollController.disconnect()
+      scrollController?.disconnect()
+      scrollController = null
       destroyTranscriptSession(activeSessionState)
 
       return true
@@ -151,6 +155,32 @@ export function bootstrapContentScript(
       }
 
       reportUnavailableStatus(dependencies.reportAvailability)
+
+      return true
+    }
+
+    scrollController = initializeScrollVirtualization(activeSessionState, {
+      afterPatch() {
+        appendObserverManager?.flushPendingMutationRecords()
+        structuralRebuildObserverManager?.flushPendingMutationRecords()
+        resizeObserverManager?.refreshObservedRecords()
+        maybeHandleMemoryGuard()
+      },
+      requestAnimationFrame: dependencies.requestAnimationFrame ?? window.requestAnimationFrame.bind(window),
+    })
+
+    function maybeHandleMemoryGuard(): boolean {
+      const pressure = estimateDetachedCachePressure(activeSessionState)
+
+      if (!shouldDisableVirtualizationForMemory(pressure, memoryGuardThreshold)) {
+        return false
+      }
+
+      if (!teardownSession()) {
+        return false
+      }
+
+      void (dependencies.disableVirtualizationForMemoryGuard ?? disableCurrentTabVirtualization)()
 
       return true
     }
@@ -178,7 +208,7 @@ export function bootstrapContentScript(
           reconnectObservers: connectObservers,
           resolveSelectors,
           schedulePatch(options) {
-            return scrollController.schedulePatch(options)
+            return scrollController?.schedulePatch(options) ?? false
           },
         })
       } finally {
@@ -208,7 +238,7 @@ export function bootstrapContentScript(
           dependencies.createResizeObserver ?? ((callback) => new ResizeObserver(callback)),
         measure: measureBubble,
         schedulePatch() {
-          return scrollController.schedulePatch()
+          return scrollController?.schedulePatch() ?? false
         },
       })
       appendObserverManager = createAppendObserverManager(activeSessionState, {
@@ -221,7 +251,7 @@ export function bootstrapContentScript(
         measure: measureBubble,
         requestDirtyRebuild: requestDirtyRebuildAndMaybeRun,
         schedulePatch(options) {
-          return scrollController.schedulePatch(options)
+          return scrollController?.schedulePatch(options) ?? false
         },
         setTimeout: dependencies.setTimeout ?? window.setTimeout.bind(window),
       })
@@ -258,7 +288,7 @@ export function bootstrapContentScript(
           }
 
           appendObserverManager?.flushPendingAppends()
-          scrollController.schedulePatch({ force: true })
+          scrollController?.schedulePatch({ force: true })
         },
         streamingIndicatorSelector: activeSelectors.streamingIndicatorSelector,
       })
@@ -267,7 +297,9 @@ export function bootstrapContentScript(
       streamingObserverManager.sync()
     }
 
-    connectObservers()
+    if (!sessionClosed) {
+      connectObservers()
+    }
   }
 
   dependencies.reportAvailability(createReportContentAvailabilityMessage(availability))

--- a/src/content/memory-guard.ts
+++ b/src/content/memory-guard.ts
@@ -1,0 +1,47 @@
+import type { TranscriptSessionState } from './state.ts'
+
+export interface DetachedCachePressure {
+  detachedNodeCount: number
+  estimatedDetachedHeight: number
+}
+
+export interface MemoryGuardThreshold {
+  detachedNodeCount: number
+  estimatedDetachedHeight: number
+}
+
+export const DEFAULT_MEMORY_GUARD_THRESHOLD: MemoryGuardThreshold = {
+  detachedNodeCount: 2_000,
+  estimatedDetachedHeight: 500_000,
+}
+
+export function estimateDetachedCachePressure(
+  state: TranscriptSessionState,
+): DetachedCachePressure {
+  return state.records.reduce<DetachedCachePressure>(
+    (pressure, record) => {
+      if (record.mounted) {
+        return pressure
+      }
+
+      pressure.detachedNodeCount += 1
+      pressure.estimatedDetachedHeight += record.measuredHeight
+
+      return pressure
+    },
+    {
+      detachedNodeCount: 0,
+      estimatedDetachedHeight: 0,
+    },
+  )
+}
+
+export function shouldDisableVirtualizationForMemory(
+  pressure: DetachedCachePressure,
+  threshold: MemoryGuardThreshold = DEFAULT_MEMORY_GUARD_THRESHOLD,
+): boolean {
+  return (
+    pressure.detachedNodeCount >= threshold.detachedNodeCount ||
+    pressure.estimatedDetachedHeight >= threshold.estimatedDetachedHeight
+  )
+}

--- a/src/content/runtime-control.ts
+++ b/src/content/runtime-control.ts
@@ -1,0 +1,42 @@
+import {
+  createDisableTabVirtualizationMessage,
+  createGetTabEnabledMessage,
+  isWorkerToContentMessage,
+} from '../shared/messages.ts'
+
+export interface RuntimeControlDependencies {
+  sendMessage(message: unknown, callback: (response: unknown) => void): void
+}
+
+export function getCurrentTabVirtualizationEnabled(
+  dependencies: RuntimeControlDependencies = createDefaultDependencies(),
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    dependencies.sendMessage(createGetTabEnabledMessage(), (response) => {
+      if (chrome.runtime.lastError !== undefined || !isWorkerToContentMessage(response)) {
+        resolve(false)
+        return
+      }
+
+      resolve(response.enabled)
+    })
+  })
+}
+
+export function disableCurrentTabVirtualization(
+  dependencies: RuntimeControlDependencies = createDefaultDependencies(),
+): Promise<void> {
+  return new Promise((resolve) => {
+    dependencies.sendMessage(createDisableTabVirtualizationMessage(), () => {
+      resolve()
+    })
+  })
+}
+
+function createDefaultDependencies(): RuntimeControlDependencies {
+  return {
+    sendMessage(message, callback) {
+      chrome.runtime.sendMessage(message, callback)
+    },
+  }
+}

--- a/src/content/startup.ts
+++ b/src/content/startup.ts
@@ -1,0 +1,31 @@
+import { createReportContentAvailabilityMessage } from '../shared/messages.ts'
+import { startContentRuntime } from './navigation.ts'
+import { getCurrentTabVirtualizationEnabled } from './runtime-control.ts'
+
+export interface ContentEntryDependencies {
+  getCurrentTabVirtualizationEnabled?(): Promise<boolean>
+  reportAvailability(message: ReturnType<typeof createReportContentAvailabilityMessage>): void
+  startContentRuntime?(): void
+}
+
+export async function bootstrapContentEntry(
+  dependencies: ContentEntryDependencies = createDefaultDependencies(),
+): Promise<void> {
+  const enabled =
+    await (dependencies.getCurrentTabVirtualizationEnabled ?? getCurrentTabVirtualizationEnabled)()
+
+  if (!enabled) {
+    dependencies.reportAvailability(createReportContentAvailabilityMessage('idle'))
+    return
+  }
+
+  ;(dependencies.startContentRuntime ?? startContentRuntime)()
+}
+
+function createDefaultDependencies(): ContentEntryDependencies {
+  return {
+    reportAvailability(message) {
+      chrome.runtime.sendMessage(message)
+    },
+  }
+}

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -5,6 +5,10 @@ export const SET_TAB_ENABLED_MESSAGE_TYPE = 'runtime/set-tab-enabled' as const
 export const POPUP_STATE_MESSAGE_TYPE = 'runtime/popup-state' as const
 export const REPORT_CONTENT_AVAILABILITY_MESSAGE_TYPE =
   'runtime/report-content-availability' as const
+export const GET_TAB_ENABLED_MESSAGE_TYPE = 'runtime/get-tab-enabled' as const
+export const TAB_ENABLED_MESSAGE_TYPE = 'runtime/tab-enabled' as const
+export const DISABLE_TAB_VIRTUALIZATION_MESSAGE_TYPE =
+  'runtime/disable-tab-virtualization' as const
 
 export interface GetPopupStateMessage {
   type: typeof GET_POPUP_STATE_MESSAGE_TYPE
@@ -24,9 +28,26 @@ export interface ReportContentAvailabilityMessage {
   type: typeof REPORT_CONTENT_AVAILABILITY_MESSAGE_TYPE
 }
 
+export interface GetTabEnabledMessage {
+  type: typeof GET_TAB_ENABLED_MESSAGE_TYPE
+}
+
+export interface TabEnabledMessage {
+  enabled: boolean
+  type: typeof TAB_ENABLED_MESSAGE_TYPE
+}
+
+export interface DisableTabVirtualizationMessage {
+  type: typeof DISABLE_TAB_VIRTUALIZATION_MESSAGE_TYPE
+}
+
 export type PopupToWorkerMessage = GetPopupStateMessage | SetTabEnabledMessage
-export type ContentToWorkerMessage = ReportContentAvailabilityMessage
+export type ContentToWorkerMessage =
+  | DisableTabVirtualizationMessage
+  | GetTabEnabledMessage
+  | ReportContentAvailabilityMessage
 export type WorkerToPopupMessage = PopupStateMessage
+export type WorkerToContentMessage = TabEnabledMessage
 
 export function createGetPopupStateMessage(): GetPopupStateMessage {
   return {
@@ -61,6 +82,25 @@ export function createReportContentAvailabilityMessage(
   }
 }
 
+export function createGetTabEnabledMessage(): GetTabEnabledMessage {
+  return {
+    type: GET_TAB_ENABLED_MESSAGE_TYPE,
+  }
+}
+
+export function createTabEnabledMessage(enabled: boolean): TabEnabledMessage {
+  return {
+    enabled,
+    type: TAB_ENABLED_MESSAGE_TYPE,
+  }
+}
+
+export function createDisableTabVirtualizationMessage(): DisableTabVirtualizationMessage {
+  return {
+    type: DISABLE_TAB_VIRTUALIZATION_MESSAGE_TYPE,
+  }
+}
+
 export function isPopupToWorkerMessage(value: unknown): value is PopupToWorkerMessage {
   if (typeof value !== 'object' || value === null) {
     return false
@@ -86,11 +126,19 @@ export function isContentToWorkerMessage(value: unknown): value is ContentToWork
     return false
   }
 
-  if (!('type' in value) || value.type !== REPORT_CONTENT_AVAILABILITY_MESSAGE_TYPE) {
+  if (!('type' in value)) {
     return false
   }
 
-  if (!('availability' in value)) {
+  if (value.type === GET_TAB_ENABLED_MESSAGE_TYPE) {
+    return true
+  }
+
+  if (value.type === DISABLE_TAB_VIRTUALIZATION_MESSAGE_TYPE) {
+    return true
+  }
+
+  if (value.type !== REPORT_CONTENT_AVAILABILITY_MESSAGE_TYPE || !('availability' in value)) {
     return false
   }
 
@@ -120,4 +168,16 @@ export function isWorkerToPopupMessage(value: unknown): value is WorkerToPopupMe
   }
 
   return value.status === 'On' || value.status === 'Off' || value.status === 'Unavailable'
+}
+
+export function isWorkerToContentMessage(value: unknown): value is WorkerToContentMessage {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  if (!('type' in value) || value.type !== TAB_ENABLED_MESSAGE_TYPE) {
+    return false
+  }
+
+  return 'enabled' in value && typeof value.enabled === 'boolean'
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -10,8 +10,18 @@ const tabStateStore = createTabStateStore()
 
 chrome.runtime.onMessage.addListener((message: unknown, sender, sendResponse) => {
   if (isContentToWorkerMessage(message)) {
-    handleContentMessage(message, sender.tab?.id ?? null, tabStateStore)
-    return false
+    void handleContentMessage(message, sender.tab?.id ?? null, {
+      refreshTab: refreshActiveTab,
+      tabStateStore,
+    })
+      .then((response) => {
+        sendResponse(response)
+      })
+      .catch(() => {
+        sendResponse(null)
+      })
+
+    return true
   }
 
   if (!isPopupToWorkerMessage(message)) {

--- a/tests/integration/content-bootstrap.spec.ts
+++ b/tests/integration/content-bootstrap.spec.ts
@@ -130,6 +130,52 @@ test('bubble이 50개일 때 spacer와 전체 mounted range를 초기 패치한�
     })
 })
 
+test('memory guard 임계값을 넘으면 탭 비활성화 요청을 보내고 transcript DOM을 복구한다', async ({
+  page,
+}) => {
+  await installFixtureRoutes(page)
+  await page.goto('http://fixture.test/c/bubble-2501?fixture=bubble-2501')
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const transcriptRoot = document.querySelector<HTMLElement>('[data-cgpt-transcript-root]')
+        const sentMessages = (window as WindowWithTestState).__sentMessages
+
+        return {
+          bubbleCount:
+            transcriptRoot?.querySelectorAll('[data-cgpt-transcript-bubble]').length ?? 0,
+          disableRequestCount: sentMessages.filter(
+            (message) =>
+              typeof message === 'object' &&
+              message !== null &&
+              'type' in message &&
+              message.type === 'runtime/disable-tab-virtualization',
+          ).length,
+          hasBottomSpacer:
+            transcriptRoot?.querySelector('[data-cgpt-bottom-spacer]') !== null,
+          hasTopSpacer: transcriptRoot?.querySelector('[data-cgpt-top-spacer]') !== null,
+          lastAvailability:
+            (window as WindowWithTestState).__reportedMessages.at(-1) !== undefined &&
+            typeof (window as WindowWithTestState).__reportedMessages.at(-1) === 'object'
+              ? ((window as WindowWithTestState).__reportedMessages.at(-1) as {
+                  availability?: string
+                }).availability ?? null
+              : null,
+          tabEnabled: (window as WindowWithTestState).__tabEnabled,
+        }
+      }),
+    )
+    .toEqual({
+      bubbleCount: 2501,
+      disableRequestCount: 1,
+      hasBottomSpacer: false,
+      hasTopSpacer: false,
+      lastAvailability: 'available',
+      tabEnabled: false,
+    })
+})
+
 test('mid-session selector failure는 Unavailable로 전환되고 navigation 전까지 inert 상태를 유지한다', async ({
   page,
 }) => {
@@ -1213,6 +1259,7 @@ function renderFixtureHtml(requestPath: string): string {
     'bubble-0': renderFixtureBody('bubble-0'),
     'bubble-49': renderFixtureBody('bubble-49'),
     'bubble-50': renderFixtureBody('bubble-50'),
+    'bubble-2501': renderFixtureBody('bubble-2501'),
     'bubble-50-alt': renderFixtureBody('bubble-50-alt'),
     missing: renderFixtureBody('missing'),
   }
@@ -1227,6 +1274,8 @@ function renderFixtureHtml(requestPath: string): string {
     ${renderFixtureBody(fixture)}
     <script>
       window.__reportedMessages = []
+      window.__sentMessages = []
+      window.__tabEnabled = true
       window.__rafCallCount = 0
       window.__allBubbles = Array.from(document.querySelectorAll('[data-cgpt-transcript-bubble]'))
       window.__fixtureBodies = ${JSON.stringify(fixtureBodies)}
@@ -1248,10 +1297,28 @@ function renderFixtureHtml(requestPath: string): string {
             addListener() {},
           },
           sendMessage(message, callback) {
-            window.__reportedMessages.push(message)
+            window.__sentMessages.push(message)
+
+            if (message?.type === 'runtime/get-tab-enabled') {
+              if (typeof callback === 'function') {
+                callback({
+                  enabled: window.__tabEnabled,
+                  type: 'runtime/tab-enabled',
+                })
+              }
+              return
+            }
+
+            if (message?.type === 'runtime/disable-tab-virtualization') {
+              window.__tabEnabled = false
+            }
+
+            if (message?.type === 'runtime/report-content-availability') {
+              window.__reportedMessages.push(message)
+            }
 
             if (typeof callback === 'function') {
-              callback(undefined)
+              callback(null)
             }
           },
         },
@@ -1295,10 +1362,18 @@ function renderFixtureBody(fixture: string | null): string {
   if (
     fixture === 'bubble-0' ||
     fixture === 'bubble-49' ||
+    fixture === 'bubble-2501' ||
     fixture === 'bubble-50' ||
     fixture === 'bubble-50-alt'
   ) {
-    const count = fixture === 'bubble-0' ? 0 : fixture === 'bubble-49' ? 49 : 50
+    const count =
+      fixture === 'bubble-0'
+        ? 0
+        : fixture === 'bubble-49'
+          ? 49
+          : fixture === 'bubble-2501'
+            ? 2501
+            : 50
     const labelPrefix = fixture === 'bubble-50-alt' ? 'Next Bubble' : 'Bubble'
 
     return `
@@ -1427,5 +1502,7 @@ interface WindowWithTestState extends Window {
   __rafCallCount: number
   __replaceFixture(fixture: string): void
   __reportedMessages: unknown[]
+  __sentMessages: Array<{ type?: string }>
+  __tabEnabled: boolean
   __tailAppendNodes: HTMLElement[]
 }

--- a/tests/unit/content-bootstrap.test.ts
+++ b/tests/unit/content-bootstrap.test.ts
@@ -262,6 +262,40 @@ describe('transcript scan integration', () => {
     expect(Array.from(fixture.transcriptRoot.children)).toHaveLength(6)
   })
 
+  it('memory guard 임계값을 넘으면 세션을 정리하고 탭 비활성화를 요청한다', () => {
+    const disableVirtualizationForMemoryGuard = vi.fn()
+    const mutationObservers: MockMutationObserverEntry[] = []
+    const fixture = makeLiveMeasuredDocumentFixture(Array.from({ length: 50 }, () => 100), {
+      viewportHeight: 200,
+    })
+
+    const result = bootstrapContentScript({
+      createMutationObserver: createMockMutationObserverFactory(mutationObservers),
+      createResizeObserver: createNoopResizeObserver,
+      disableVirtualizationForMemoryGuard,
+      document,
+      memoryGuardThreshold: {
+        detachedNodeCount: 1,
+        estimatedDetachedHeight: 1,
+      },
+      pathname: '/c/example',
+      reportAvailability() {},
+      requestAnimationFrame(callback) {
+        callback(0)
+        return 1
+      },
+    })
+
+    expect(disableVirtualizationForMemoryGuard).toHaveBeenCalledTimes(1)
+    expect(result.sessionState?.records).toHaveLength(0)
+    expect(result.sessionState?.mountedRange).toBeNull()
+    expect(fixture.transcriptRoot.querySelector('[data-cgpt-top-spacer]')).toBeNull()
+    expect(fixture.transcriptRoot.querySelector('[data-cgpt-bottom-spacer]')).toBeNull()
+    expect(
+      fixture.transcriptRoot.querySelectorAll('[data-cgpt-transcript-bubble]'),
+    ).toHaveLength(50)
+  })
+
   it('reports unavailable and becomes inert when selectors disappear mid-session', () => {
     const reports: unknown[] = []
     const mutationObservers: MockMutationObserverEntry[] = []

--- a/tests/unit/content-controller.test.ts
+++ b/tests/unit/content-controller.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { handleContentMessage } from '../../src/background/content-controller.ts'
+import { createTabStateStore } from '../../src/background/tab-state.ts'
+import {
+  DISABLE_TAB_VIRTUALIZATION_MESSAGE_TYPE,
+  GET_TAB_ENABLED_MESSAGE_TYPE,
+  REPORT_CONTENT_AVAILABILITY_MESSAGE_TYPE,
+  TAB_ENABLED_MESSAGE_TYPE,
+  createDisableTabVirtualizationMessage,
+  createGetTabEnabledMessage,
+  createReportContentAvailabilityMessage,
+  createTabEnabledMessage,
+  isContentToWorkerMessage,
+  isWorkerToContentMessage,
+} from '../../src/shared/messages.ts'
+
+describe('content-worker message contracts', () => {
+  it('creates content control request messages', () => {
+    expect(createGetTabEnabledMessage()).toEqual({
+      type: GET_TAB_ENABLED_MESSAGE_TYPE,
+    })
+    expect(createDisableTabVirtualizationMessage()).toEqual({
+      type: DISABLE_TAB_VIRTUALIZATION_MESSAGE_TYPE,
+    })
+    expect(createTabEnabledMessage(true)).toEqual({
+      enabled: true,
+      type: TAB_ENABLED_MESSAGE_TYPE,
+    })
+  })
+
+  it('recognizes valid content-to-worker messages', () => {
+    expect(
+      isContentToWorkerMessage({
+        availability: 'available',
+        type: REPORT_CONTENT_AVAILABILITY_MESSAGE_TYPE,
+      }),
+    ).toBe(true)
+    expect(isContentToWorkerMessage({ type: GET_TAB_ENABLED_MESSAGE_TYPE })).toBe(true)
+    expect(isContentToWorkerMessage({ type: DISABLE_TAB_VIRTUALIZATION_MESSAGE_TYPE })).toBe(true)
+  })
+
+  it('recognizes valid worker-to-content messages', () => {
+    expect(
+      isWorkerToContentMessage({
+        enabled: false,
+        type: TAB_ENABLED_MESSAGE_TYPE,
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('handleContentMessage', () => {
+  it('content availability 보고를 tab state에 반영한다', async () => {
+    const store = createTabStateStore()
+
+    await expect(
+      handleContentMessage(createReportContentAvailabilityMessage('available'), 7, {
+        refreshTab: async () => {},
+        tabStateStore: store,
+      }),
+    ).resolves.toBeNull()
+
+    expect(store.getTabAvailability(7)).toBe('available')
+  })
+
+  it('sender tab의 enabled 상태를 응답한다', async () => {
+    const store = createTabStateStore([[7, true]])
+
+    await expect(
+      handleContentMessage(createGetTabEnabledMessage(), 7, {
+        refreshTab: async () => {},
+        tabStateStore: store,
+      }),
+    ).resolves.toEqual(createTabEnabledMessage(true))
+  })
+
+  it('memory guard 요청이 오면 sender tab을 끄고 refresh한다', async () => {
+    const store = createTabStateStore([[7, true]])
+    const refreshTab = vi.fn(async () => {})
+
+    await expect(
+      handleContentMessage(createDisableTabVirtualizationMessage(), 7, {
+        refreshTab,
+        tabStateStore: store,
+      }),
+    ).resolves.toBeNull()
+
+    expect(store.getTabPreference(7)).toBe(false)
+    expect(refreshTab).toHaveBeenCalledWith(7)
+  })
+
+  it('sender tab id가 없으면 disable 요청을 무시한다', async () => {
+    const store = createTabStateStore([[7, true]])
+    const refreshTab = vi.fn(async () => {})
+
+    await expect(
+      handleContentMessage(createDisableTabVirtualizationMessage(), null, {
+        refreshTab,
+        tabStateStore: store,
+      }),
+    ).resolves.toBeNull()
+
+    expect(store.getTabPreference(7)).toBe(true)
+    expect(refreshTab).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/content-memory-guard.test.ts
+++ b/tests/unit/content-memory-guard.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import {
+  estimateDetachedCachePressure,
+  shouldDisableVirtualizationForMemory,
+  type MemoryGuardThreshold,
+} from '../../src/content/memory-guard.ts'
+import type { BubbleRecord, TranscriptSessionState } from '../../src/content/state.ts'
+
+describe('estimateDetachedCachePressure', () => {
+  it('unmounted record만 detached pressure로 계산한다', () => {
+    const sessionState = makeSessionState(
+      [
+        { height: 100, mounted: true },
+        { height: 120, mounted: false },
+        { height: 80, mounted: false },
+        { height: 60, mounted: true },
+      ],
+    )
+
+    expect(estimateDetachedCachePressure(sessionState)).toEqual({
+      detachedNodeCount: 2,
+      estimatedDetachedHeight: 200,
+    })
+  })
+})
+
+describe('shouldDisableVirtualizationForMemory', () => {
+  it('node count threshold를 넘으면 guard를 발동한다', () => {
+    const threshold: MemoryGuardThreshold = {
+      detachedNodeCount: 3,
+      estimatedDetachedHeight: 1_000,
+    }
+
+    expect(
+      shouldDisableVirtualizationForMemory(
+        {
+          detachedNodeCount: 3,
+          estimatedDetachedHeight: 100,
+        },
+        threshold,
+      ),
+    ).toBe(true)
+  })
+
+  it('estimated height threshold를 넘으면 guard를 발동한다', () => {
+    const threshold: MemoryGuardThreshold = {
+      detachedNodeCount: 10,
+      estimatedDetachedHeight: 250,
+    }
+
+    expect(
+      shouldDisableVirtualizationForMemory(
+        {
+          detachedNodeCount: 2,
+          estimatedDetachedHeight: 251,
+        },
+        threshold,
+      ),
+    ).toBe(true)
+  })
+
+  it('threshold 아래면 guard를 발동하지 않는다', () => {
+    const threshold: MemoryGuardThreshold = {
+      detachedNodeCount: 5,
+      estimatedDetachedHeight: 400,
+    }
+
+    expect(
+      shouldDisableVirtualizationForMemory(
+        {
+          detachedNodeCount: 4,
+          estimatedDetachedHeight: 399,
+        },
+        threshold,
+      ),
+    ).toBe(false)
+  })
+})
+
+function makeSessionState(
+  recordsInput: Array<{ height: number; mounted: boolean }>,
+): TranscriptSessionState {
+  document.body.innerHTML = ''
+
+  const transcriptRoot = document.createElement('section')
+  const scrollContainer = document.createElement('main')
+  const records: BubbleRecord[] = recordsInput.map(({ height, mounted }, index) => {
+    const node = document.createElement('article')
+    node.textContent = `Bubble ${index}`
+
+    if (mounted) {
+      transcriptRoot.append(node)
+    }
+
+    return {
+      index,
+      measuredHeight: height,
+      mounted,
+      node,
+      pinned: false,
+    }
+  })
+
+  scrollContainer.append(transcriptRoot)
+  document.body.append(scrollContainer)
+
+  return {
+    anchor: null,
+    dirtyRebuildReason: null,
+    isStreaming: false,
+    mountedRange: null,
+    pendingScrollCorrection: 0,
+    prefixSums: buildPrefixSums(recordsInput.map(({ height }) => height)),
+    records,
+    scrollContainer,
+    transcriptRoot,
+  }
+}
+
+function buildPrefixSums(heights: number[]): number[] {
+  return heights.reduce<number[]>((prefixSums, height) => {
+    const previousHeight = prefixSums[prefixSums.length - 1] ?? 0
+    prefixSums.push(previousHeight + height)
+    return prefixSums
+  }, [])
+}

--- a/tests/unit/content-startup.test.ts
+++ b/tests/unit/content-startup.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { bootstrapContentEntry } from '../../src/content/startup.ts'
+
+describe('bootstrapContentEntry', () => {
+  it('현재 탭이 활성화되어 있으면 content runtime을 시작한다', async () => {
+    const reportAvailability = vi.fn()
+    const startContentRuntime = vi.fn()
+
+    await bootstrapContentEntry({
+      getCurrentTabVirtualizationEnabled: async () => true,
+      reportAvailability,
+      startContentRuntime,
+    })
+
+    expect(startContentRuntime).toHaveBeenCalledTimes(1)
+    expect(reportAvailability).not.toHaveBeenCalled()
+  })
+
+  it('현재 탭이 비활성화되어 있으면 idle을 보고하고 runtime을 시작하지 않는다', async () => {
+    const reportAvailability = vi.fn()
+    const startContentRuntime = vi.fn()
+
+    await bootstrapContentEntry({
+      getCurrentTabVirtualizationEnabled: async () => false,
+      reportAvailability,
+      startContentRuntime,
+    })
+
+    expect(reportAvailability).toHaveBeenCalledWith({
+      availability: 'idle',
+      type: 'runtime/report-content-availability',
+    })
+    expect(startContentRuntime).not.toHaveBeenCalled()
+  })
+})

--- a/todo.md
+++ b/todo.md
@@ -336,17 +336,17 @@
 
 ## 16. Memory guard
 
-- [ ] Add detached-cache pressure heuristic
-- [ ] Define internal safety threshold
+- [x] Add detached-cache pressure heuristic
+- [x] Define internal safety threshold
 - [ ] On threshold exceeded:
-  - [ ] disable virtualization for the tab
-  - [ ] trigger restore-through-refresh behavior
-- [ ] Add tests for memory guard path
+  - [x] disable virtualization for the tab
+  - [x] trigger restore-through-refresh behavior
+- [x] Add tests for memory guard path
 
 ### Acceptance criteria
-- [ ] Memory guard can be triggered in tests
-- [ ] Trigger path disables virtualization safely
-- [ ] Restore-through-refresh path is wired
+- [x] Memory guard can be triggered in tests
+- [x] Trigger path disables virtualization safely
+- [x] Restore-through-refresh path is wired
 
 ---
 


### PR DESCRIPTION
## 요약
- detached cache pressure를 detached 개수와 추정 높이 기준으로 계산하는 memory guard를 추가했습니다.
- content script가 탭 활성화 상태를 조회하고, memory guard 발동 시 worker를 통해 탭 비활성화와 refresh 복구를 요청하도록 연결했습니다.
- unit/integration 테스트와 Playwright fixture를 갱신하고 todo.md의 16번 섹션을 실제 검증 결과에 맞게 업데이트했습니다.

## 검증
- pnpm run test

Closes #19