### PR TITLE
작업 17: 회귀 테스트와 성능 계측

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "pnpm run test:unit && pnpm run test:integration",
     "test:unit": "vitest run",
     "pretest:integration": "pnpm run build",
-    "test:integration": "playwright test"
+    "test:integration": "env -u NO_COLOR playwright test"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -20,6 +20,7 @@ import {
   handleSelectorStartupFailure,
   reportUnavailableStatus,
 } from './failure.ts'
+import { reportVirtualizationMetrics } from './debug.ts'
 import {
   DEFAULT_MEMORY_GUARD_THRESHOLD,
   estimateDetachedCachePressure,
@@ -150,6 +151,8 @@ export function bootstrapContentScript(
     }
 
     const handleMidSessionSelectorFailure = () => {
+      reportVirtualizationMetrics('selector-failure', activeSessionState)
+
       if (!teardownSession()) {
         return false
       }
@@ -164,6 +167,7 @@ export function bootstrapContentScript(
         appendObserverManager?.flushPendingMutationRecords()
         structuralRebuildObserverManager?.flushPendingMutationRecords()
         resizeObserverManager?.refreshObservedRecords()
+        reportVirtualizationMetrics('patch-applied', activeSessionState)
         maybeHandleMemoryGuard()
       },
       requestAnimationFrame: dependencies.requestAnimationFrame ?? window.requestAnimationFrame.bind(window),
@@ -175,6 +179,8 @@ export function bootstrapContentScript(
       if (!shouldDisableVirtualizationForMemory(pressure, memoryGuardThreshold)) {
         return false
       }
+
+      reportVirtualizationMetrics('memory-guard-trip', activeSessionState)
 
       if (!teardownSession()) {
         return false

--- a/src/content/debug.ts
+++ b/src/content/debug.ts
@@ -1,0 +1,172 @@
+import { estimateDetachedCachePressure } from './memory-guard.ts'
+import type { TranscriptSessionState } from './state.ts'
+
+const TOP_SPACER_SELECTOR = '[data-cgpt-top-spacer]'
+const BOTTOM_SPACER_SELECTOR = '[data-cgpt-bottom-spacer]'
+
+export const DEBUG_SESSION_STORAGE_KEY = 'cgpt-virtualizer:debug'
+
+export interface VirtualizationMetrics {
+  bottomSpacerHeight: number
+  detachedNodeCount: number
+  directChildCount: number
+  estimatedDetachedHeight: number
+  isStreaming: boolean
+  mountedBubbleCount: number
+  mountedRange: { end: number; start: number } | null
+  mountedWindowHeight: number
+  scrollTop: number
+  topSpacerHeight: number
+  totalBubbleCount: number
+  totalHeight: number
+  viewportHeight: number
+}
+
+type DebugSink = (...args: unknown[]) => void
+
+export function createDebugLogger(
+  enabled: boolean,
+  sink: DebugSink = console.debug.bind(console) as DebugSink,
+): (event: string, payload?: unknown) => void {
+  return (event, payload) => {
+    if (!enabled) {
+      return
+    }
+
+    sink('[cgpt-virtualizer]', event, payload)
+  }
+}
+
+export function isDebugModeEnabled(
+  storage: Pick<Storage, 'getItem'> | null = resolveDebugStorage(),
+): boolean {
+  try {
+    return storage?.getItem(DEBUG_SESSION_STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function recordVirtualizationMetrics(
+  state: TranscriptSessionState,
+): VirtualizationMetrics {
+  const pressure = estimateDetachedCachePressure(state)
+  const totalHeight =
+    state.records.length === 0 ? 0 : (state.prefixSums[state.prefixSums.length - 1] ?? 0)
+
+  return {
+    bottomSpacerHeight: resolveSpacerHeight(state.transcriptRoot, BOTTOM_SPACER_SELECTOR),
+    detachedNodeCount: pressure.detachedNodeCount,
+    directChildCount: state.transcriptRoot.children.length,
+    estimatedDetachedHeight: pressure.estimatedDetachedHeight,
+    isStreaming: state.isStreaming,
+    mountedBubbleCount:
+      state.mountedRange === null ? 0 : state.mountedRange.end - state.mountedRange.start + 1,
+    mountedRange: state.mountedRange,
+    mountedWindowHeight: resolveMountedWindowHeight(state),
+    scrollTop: state.scrollContainer.scrollTop,
+    topSpacerHeight: resolveSpacerHeight(state.transcriptRoot, TOP_SPACER_SELECTOR),
+    totalBubbleCount: state.records.length,
+    totalHeight,
+    viewportHeight: resolveViewportHeight(state.scrollContainer),
+  }
+}
+
+export function reportVirtualizationMetrics(
+  event: string,
+  state: TranscriptSessionState,
+  dependencies: {
+    sink?: DebugSink
+    storage?: Pick<Storage, 'getItem'> | null
+  } = {},
+): VirtualizationMetrics | null {
+  const storage =
+    dependencies.storage === undefined ? resolveDebugStorage() : dependencies.storage
+
+  if (!isDebugModeEnabled(storage)) {
+    return null
+  }
+
+  const metrics = recordVirtualizationMetrics(state)
+  createDebugLogger(true, dependencies.sink)(event, metrics)
+
+  return metrics
+}
+
+export function assertMountedWindowBounds(
+  state: TranscriptSessionState,
+  start: number,
+  end: number,
+): void {
+  const expectedMountedCount = end - start + 1
+  const directChildren = Array.from(state.transcriptRoot.children)
+  const directBubbleChildren = directChildren.filter((child) => !isSpacer(child))
+
+  if (directBubbleChildren.length !== expectedMountedCount) {
+    throw new Error('Mounted window bubble 수가 기대 범위를 벗어났습니다.')
+  }
+
+  if (directChildren.length !== expectedMountedCount + 2) {
+    throw new Error('Mounted window direct child 수가 spacer를 포함한 기대치와 다릅니다.')
+  }
+
+  for (const record of state.records) {
+    const shouldBeMounted = record.index >= start && record.index <= end
+    const isDirectChild = record.node.parentElement === state.transcriptRoot
+
+    if (record.mounted !== shouldBeMounted) {
+      throw new Error('Mounted flag가 현재 DOM window와 일치하지 않습니다.')
+    }
+
+    if (isDirectChild !== shouldBeMounted) {
+      throw new Error('DOM에 연결된 bubble이 mounted window와 일치하지 않습니다.')
+    }
+  }
+}
+
+function isSpacer(element: Element): boolean {
+  return (
+    element.matches(TOP_SPACER_SELECTOR) ||
+    element.matches(BOTTOM_SPACER_SELECTOR)
+  )
+}
+
+function resolveMountedWindowHeight(state: TranscriptSessionState): number {
+  if (state.mountedRange === null) {
+    return 0
+  }
+
+  const end = state.prefixSums[state.mountedRange.end] ?? 0
+  const start =
+    state.mountedRange.start === 0 ? 0 : (state.prefixSums[state.mountedRange.start - 1] ?? 0)
+
+  return end - start
+}
+
+function resolveSpacerHeight(root: HTMLElement, selector: string): number {
+  const spacer = root.querySelector<HTMLElement>(`:scope > ${selector}`)
+
+  if (spacer === null) {
+    return 0
+  }
+
+  const parsedHeight = Number.parseFloat(spacer.style.height)
+
+  return Number.isNaN(parsedHeight) ? 0 : parsedHeight
+}
+
+function resolveViewportHeight(scrollContainer: HTMLElement): number {
+  return scrollContainer.clientHeight || scrollContainer.getBoundingClientRect().height
+}
+
+function resolveDebugStorage(): Pick<Storage, 'getItem'> | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}

--- a/src/content/patch.ts
+++ b/src/content/patch.ts
@@ -1,3 +1,4 @@
+import { assertMountedWindowBounds, isDebugModeEnabled } from './debug.ts'
 import type { BubbleRecord, TranscriptSessionState } from './state.ts'
 
 const TOP_SPACER_ATTRIBUTE = 'data-cgpt-top-spacer'
@@ -96,6 +97,10 @@ export function patchMountedRange(
   state.transcriptRoot.insertBefore(fragment, bottomSpacer)
   updateMountedFlags(state.records, start, end)
   state.mountedRange = { start, end }
+
+  if (isDebugModeEnabled()) {
+    assertMountedWindowBounds(state, start, end)
+  }
 }
 
 function detachMountedRangeOutsideNextWindow(

--- a/tests/integration/content-bootstrap.spec.ts
+++ b/tests/integration/content-bootstrap.spec.ts
@@ -507,6 +507,56 @@ test('streaming 중 scroll은 mounted range 패치를 멈춘다', async ({ page 
     })
 })
 
+test('streaming 종료 후에는 scroll-driven mounted range patch가 다시 동작한다', async ({
+  page,
+}) => {
+  await installFixtureRoutes(page)
+  await page.goto('http://fixture.test/c/bubble-50?fixture=bubble-50')
+
+  await expectInitialMountedWindow(page)
+
+  await page.evaluate(async () => {
+    const scrollContainer = document.querySelector<HTMLElement>('[data-cgpt-scroll-container]')
+    const streamingIndicator = document.querySelector<HTMLElement>('[data-cgpt-streaming-indicator]')
+
+    if (scrollContainer === null || streamingIndicator === null) {
+      throw new Error('streaming fixture is missing')
+    }
+
+    streamingIndicator.removeAttribute('hidden')
+    scrollContainer.scrollTop = 250
+    scrollContainer.dispatchEvent(new Event('scroll'))
+
+    await new Promise((resolve) => window.setTimeout(resolve, 50))
+
+    streamingIndicator.setAttribute('hidden', '')
+  })
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const transcriptRoot = document.querySelector('[data-cgpt-transcript-root]')
+        const children = transcriptRoot === null ? [] : Array.from(transcriptRoot.children)
+
+        return {
+          childCount: children.length,
+          firstBubbleText: children[1]?.textContent ?? null,
+          lastBubbleText: children.at(-2)?.textContent ?? null,
+          placeholderCount:
+            transcriptRoot?.querySelectorAll('[data-cgpt-streaming-gap-placeholder]').length ?? 0,
+          rafCallCount: (window as WindowWithTestState).__rafCallCount,
+        }
+      }),
+    )
+    .toEqual({
+      childCount: 9,
+      firstBubbleText: 'Bubble 0',
+      lastBubbleText: 'Bubble 6',
+      placeholderCount: 0,
+      rafCallCount: 3,
+    })
+})
+
 test('streaming gap에 진입하면 placeholder를 표시하고 종료 시 제거한다', async ({ page }) => {
   await installFixtureRoutes(page)
   await page.goto('http://fixture.test/c/bubble-50?fixture=bubble-50')

--- a/tests/unit/content-bootstrap.test.ts
+++ b/tests/unit/content-bootstrap.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { bootstrapContentScript } from '../../src/content/bootstrap.ts'
+import { DEBUG_SESSION_STORAGE_KEY } from '../../src/content/debug.ts'
 import { resolveAvailability } from '../../src/content/availability.ts'
 import {
   CONTENT_SELECTOR_REGISTRY,
@@ -260,6 +261,42 @@ describe('transcript scan integration', () => {
     expect(result.sessionState?.records.slice(0, 4).every((record) => record.mounted)).toBe(true)
     expect(result.sessionState?.records.slice(4).every((record) => !record.mounted)).toBe(true)
     expect(Array.from(fixture.transcriptRoot.children)).toHaveLength(6)
+  })
+
+  it('debug mode가 켜져 있으면 초기 patch metrics를 기록한다', () => {
+    const bubbleHeights = Array.from({ length: 50 }, () => 100)
+    const fixture = makeMeasuredDocumentFixture(bubbleHeights, {
+      viewportHeight: 200,
+    })
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+    window.sessionStorage.setItem(DEBUG_SESSION_STORAGE_KEY, '1')
+
+    try {
+      bootstrapContentScript({
+        createResizeObserver: createNoopResizeObserver,
+        document: fixture.document,
+        pathname: '/c/example',
+        reportAvailability() {},
+        requestAnimationFrame(callback) {
+          callback(0)
+          return 1
+        },
+      })
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        '[cgpt-virtualizer]',
+        'patch-applied',
+        expect.objectContaining({
+          directChildCount: 6,
+          mountedBubbleCount: 4,
+          mountedRange: { end: 3, start: 0 },
+        }),
+      )
+    } finally {
+      window.sessionStorage.removeItem(DEBUG_SESSION_STORAGE_KEY)
+      debugSpy.mockRestore()
+    }
   })
 
   it('memory guard 임계값을 넘으면 세션을 정리하고 탭 비활성화를 요청한다', () => {

--- a/tests/unit/content-debug.test.ts
+++ b/tests/unit/content-debug.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  assertMountedWindowBounds,
+  recordVirtualizationMetrics,
+  reportVirtualizationMetrics,
+} from '../../src/content/debug.ts'
+import { patchMountedRange } from '../../src/content/patch.ts'
+import type { BubbleRecord, TranscriptSessionState } from '../../src/content/state.ts'
+
+describe('recordVirtualizationMetrics', () => {
+  it('현재 mounted window metrics를 계산한다', () => {
+    const fixture = makeSessionFixture([100, 100, 100, 100])
+
+    patchMountedRange(fixture.sessionState, 1, 2)
+    fixture.scrollContainer.scrollTop = 150
+
+    expect(recordVirtualizationMetrics(fixture.sessionState)).toEqual({
+      bottomSpacerHeight: 100,
+      detachedNodeCount: 2,
+      directChildCount: 4,
+      estimatedDetachedHeight: 200,
+      isStreaming: false,
+      mountedBubbleCount: 2,
+      mountedRange: { end: 2, start: 1 },
+      mountedWindowHeight: 200,
+      scrollTop: 150,
+      topSpacerHeight: 100,
+      totalBubbleCount: 4,
+      totalHeight: 400,
+      viewportHeight: 200,
+    })
+  })
+})
+
+describe('assertMountedWindowBounds', () => {
+  it('mounted range 밖 bubble이 direct child로 남아 있으면 실패한다', () => {
+    const fixture = makeSessionFixture([100, 100, 100, 100])
+
+    patchMountedRange(fixture.sessionState, 1, 2)
+    fixture.transcriptRoot.insertBefore(
+      fixture.records[0]!.node,
+      fixture.transcriptRoot.querySelector('[data-cgpt-bottom-spacer]'),
+    )
+
+    expect(() => {
+      assertMountedWindowBounds(fixture.sessionState, 1, 2)
+    }).toThrow('Mounted window bubble 수가 기대 범위를 벗어났습니다.')
+  })
+})
+
+describe('reportVirtualizationMetrics', () => {
+  it('debug storage flag가 켜져 있을 때만 metrics를 기록한다', () => {
+    const fixture = makeSessionFixture([100, 100, 100, 100])
+    const sink = vi.fn()
+
+    patchMountedRange(fixture.sessionState, 0, 1)
+
+    expect(
+      reportVirtualizationMetrics('patch-applied', fixture.sessionState, {
+        sink,
+        storage: { getItem: () => '1' },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        mountedBubbleCount: 2,
+        mountedRange: { end: 1, start: 0 },
+      }),
+    )
+    expect(sink).toHaveBeenCalledWith(
+      '[cgpt-virtualizer]',
+      'patch-applied',
+      expect.objectContaining({
+        mountedBubbleCount: 2,
+        mountedRange: { end: 1, start: 0 },
+      }),
+    )
+
+    sink.mockClear()
+
+    expect(
+      reportVirtualizationMetrics('patch-applied', fixture.sessionState, {
+        sink,
+        storage: { getItem: () => null },
+      }),
+    ).toBeNull()
+    expect(sink).not.toHaveBeenCalled()
+  })
+})
+
+function makeSessionFixture(
+  heights: number[],
+): {
+  records: BubbleRecord[]
+  scrollContainer: HTMLElement
+  sessionState: TranscriptSessionState
+  transcriptRoot: HTMLElement
+} {
+  document.body.innerHTML = ''
+
+  const transcriptRoot = document.createElement('section')
+  const scrollContainer = document.createElement('main')
+  const records = heights.map((height, index): BubbleRecord => {
+    const node = document.createElement('article')
+
+    node.textContent = `Bubble ${index}`
+    transcriptRoot.append(node)
+
+    return {
+      index,
+      measuredHeight: height,
+      mounted: true,
+      node,
+      pinned: false,
+    }
+  })
+
+  Object.defineProperty(scrollContainer, 'clientHeight', {
+    configurable: true,
+    value: 200,
+  })
+  scrollContainer.getBoundingClientRect = () =>
+    ({
+      height: 200,
+      top: 0,
+    }) as DOMRect
+  scrollContainer.scrollTop = 0
+  scrollContainer.append(transcriptRoot)
+  document.body.append(scrollContainer)
+
+  return {
+    records,
+    scrollContainer,
+    sessionState: {
+      anchor: null,
+      dirtyRebuildReason: null,
+      isStreaming: false,
+      mountedRange: null,
+      pendingScrollCorrection: 0,
+      prefixSums: buildPrefixSums(heights),
+      records,
+      scrollContainer,
+      transcriptRoot,
+    },
+    transcriptRoot,
+  }
+}
+
+function buildPrefixSums(heights: number[]): number[] {
+  return heights.reduce<number[]>((prefixSums, height) => {
+    const previous = prefixSums[prefixSums.length - 1] ?? 0
+
+    prefixSums.push(previous + height)
+    return prefixSums
+  }, [])
+}

--- a/tests/unit/popup-worker.test.ts
+++ b/tests/unit/popup-worker.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
+import { handleContentMessage } from '../../src/background/content-controller.ts'
 import {
   REPORT_CONTENT_AVAILABILITY_MESSAGE_TYPE,
   GET_POPUP_STATE_MESSAGE_TYPE,
   POPUP_STATE_MESSAGE_TYPE,
   SET_TAB_ENABLED_MESSAGE_TYPE,
+  createGetTabEnabledMessage,
   createGetPopupStateMessage,
   createPopupStateMessage,
   createReportContentAvailabilityMessage,
@@ -14,6 +16,7 @@ import {
 } from '../../src/shared/messages.ts'
 import { handlePopupMessage } from '../../src/background/popup-controller.ts'
 import { createPopupState, createTabStateStore } from '../../src/background/tab-state.ts'
+import { bootstrapContentEntry } from '../../src/content/startup.ts'
 import { createPopupViewModel } from '../../src/popup-view.ts'
 
 describe('popup-worker message contracts', () => {
@@ -241,6 +244,89 @@ describe('popup controller', () => {
       status: 'Unavailable',
       type: POPUP_STATE_MESSAGE_TYPE,
     })
+  })
+})
+
+describe('toggle flow regression', () => {
+  it('활성 탭 on/off 토글이 content startup gating까지 일관되게 반영된다', async () => {
+    const store = createTabStateStore()
+    const refreshedTabIds: number[] = []
+
+    store.setTabAvailability(7, 'available')
+
+    const getCurrentTabVirtualizationEnabled = async () => {
+      const response = await handleContentMessage(createGetTabEnabledMessage(), 7, {
+        refreshTab: async () => {},
+        tabStateStore: store,
+      })
+
+      if (response === null) {
+        throw new Error('tab enabled 응답이 필요합니다.')
+      }
+
+      return response.enabled
+    }
+
+    await expect(
+      handlePopupMessage(createSetTabEnabledMessage(true), {
+        getActiveTabId: async () => 7,
+        refreshActiveTab: async (tabId) => {
+          refreshedTabIds.push(tabId)
+        },
+        tabStateStore: store,
+      }),
+    ).resolves.toEqual({
+      enabled: true,
+      status: 'On',
+      type: POPUP_STATE_MESSAGE_TYPE,
+    })
+
+    let reports: Array<ReturnType<typeof createReportContentAvailabilityMessage>> = []
+    let startCount = 0
+
+    await bootstrapContentEntry({
+      getCurrentTabVirtualizationEnabled,
+      reportAvailability(message) {
+        reports.push(message)
+      },
+      startContentRuntime() {
+        startCount += 1
+      },
+    })
+
+    expect(startCount).toBe(1)
+    expect(reports).toEqual([])
+
+    await expect(
+      handlePopupMessage(createSetTabEnabledMessage(false), {
+        getActiveTabId: async () => 7,
+        refreshActiveTab: async (tabId) => {
+          refreshedTabIds.push(tabId)
+        },
+        tabStateStore: store,
+      }),
+    ).resolves.toEqual({
+      enabled: false,
+      status: 'Off',
+      type: POPUP_STATE_MESSAGE_TYPE,
+    })
+
+    reports = []
+    startCount = 0
+
+    await bootstrapContentEntry({
+      getCurrentTabVirtualizationEnabled,
+      reportAvailability(message) {
+        reports.push(message)
+      },
+      startContentRuntime() {
+        startCount += 1
+      },
+    })
+
+    expect(startCount).toBe(0)
+    expect(reports).toEqual([createReportContentAvailabilityMessage('idle')])
+    expect(refreshedTabIds).toEqual([7, 7])
   })
 })
 

--- a/todo.md
+++ b/todo.md
@@ -352,21 +352,21 @@
 
 ## 17. Regression and performance coverage
 
-- [ ] Add regression tests for:
-  - [ ] selector failure
-  - [ ] memory guard
-  - [ ] unavailable popup state
-  - [ ] on/off toggle flow
-  - [ ] dirty rebuild after unsafe mutation
-  - [ ] streaming resume path
-- [ ] Add performance/debug instrumentation hooks
-- [ ] Add at least one assertion around mounted window size / mounted bubble count
-- [ ] Run full test suite cleanly
+- [x] Add regression tests for:
+  - [x] selector failure
+  - [x] memory guard
+  - [x] unavailable popup state
+  - [x] on/off toggle flow
+  - [x] dirty rebuild after unsafe mutation
+  - [x] streaming resume path
+- [x] Add performance/debug instrumentation hooks
+- [x] Add at least one assertion around mounted window size / mounted bubble count
+- [x] Run full test suite cleanly
 
 ### Acceptance criteria
-- [ ] Full test suite passes
-- [ ] Mounted window remains bounded as expected
-- [ ] Debug instrumentation can be enabled in development
+- [x] Full test suite passes
+- [x] Mounted window remains bounded as expected
+- [x] Debug instrumentation can be enabled in development
 
 ---
 


### PR DESCRIPTION
## 요약
- content runtime에 디버그 계측과 mounted window invariant를 추가했습니다.
- toggle on/off 흐름과 streaming resume 경로 회귀 테스트를 보강했습니다.
- Playwright 실행 전에 NO_COLOR를 해제해 통합 테스트 출력 경고를 제거했습니다.

## 검증
- pnpm install --frozen-lockfile
- pnpm exec vitest run tests/unit/content-debug.test.ts tests/unit/content-bootstrap.test.ts tests/unit/popup-worker.test.ts
- pnpm run build
- pnpm exec playwright test tests/integration/content-bootstrap.spec.ts --grep "streaming 종료 후에는 scroll-driven mounted range patch가 다시 동작한다"
- pnpm run test

Closes #20