### PR TITLE
docs: README와 Chrome 수동 로드 가이드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,90 @@
+# cgpt-virtualizer
+
+`cgpt-virtualizer`는 긴 ChatGPT 대화에서 transcript bubble DOM을 가상화하는 Chrome MV3 확장 프로그램입니다. 화면 밖 bubble을 live DOM 밖으로 이동시키고, 다시 보일 때 같은 DOM 노드를 재장착하는 방식으로 스크롤 비용과 DOM 압력을 줄이는 것을 목표로 합니다.
+
+## 현재 구현 상태
+
+- 확장은 `https://chatgpt.com/*`에 주입되지만 실제 초기화는 `/c/:conversationId` 경로에서만 시도합니다.
+- transcript bubble이 50개 이상일 때만 가상화를 활성화합니다.
+- 팝업은 탭별 On/Off 토글과 `On` / `Off` / `Unavailable` 상태를 제공합니다.
+- 현재 selector registry는 테스트 fixture 기준의 placeholder 선택자를 사용합니다. 그래서 실제 ChatGPT DOM에서는 `Unavailable` 상태가 나올 수 있습니다.
+
+## 런타임 구성
+
+### Popup
+
+- 파일: `src/popup.ts`, `src/popup-view.ts`
+- 역할: 현재 탭의 상태를 조회하고 On/Off 토글을 서비스 워커에 전달합니다.
+
+### Service worker
+
+- 파일: `src/worker.ts`, `src/background/*`
+- 역할: `tabId` 기준으로 탭별 설정과 콘텐츠 가용성 상태를 메모리에 유지하고, 토글 시 현재 탭을 새로고침합니다.
+
+### Content script
+
+- 진입점: `src/content.ts`
+- 세부 모듈:
+  - `startup.ts`: 현재 탭 활성화 여부를 확인하고 콘텐츠 런타임을 시작합니다.
+  - `bootstrap.ts`: selector 해석, transcript 스캔, 세션 상태 초기화, observer 연결을 담당합니다.
+  - `scroll.ts`, `patch.ts`, `range.ts`: mounted range 계산과 spacer 기반 DOM 패치를 수행합니다.
+  - `resize.ts`, `anchor.ts`: mounted bubble 높이 변경과 읽기 위치 보정을 처리합니다.
+  - `append.ts`, `bottom-follow.ts`: tail append 배치와 near-bottom follow를 처리합니다.
+  - `streaming.ts`, `placeholder.ts`: streaming 중 mount/unmount 일시 중단과 안내 placeholder를 처리합니다.
+  - `rebuild.ts`, `failure.ts`, `navigation.ts`: dirty rebuild, mid-session selector failure, SPA 네비게이션 리셋을 담당합니다.
+
+### Shared contracts
+
+- 파일: `src/shared/*`
+- 역할: popup, worker, content script가 공통으로 쓰는 메시지 타입, 상태 타입, 경로 파서, 상수를 정의합니다.
+
+## 핵심 동작
+
+- transcript bubble 측정값을 prefix sum으로 유지하고, 현재 스크롤 위치 기준 mounted range를 이진 탐색으로 계산합니다.
+- mounted range 바깥은 top spacer와 bottom spacer 높이로 대체합니다.
+- overscan은 위아래 각각 1 viewport입니다.
+- clean tail append는 150ms quiet period로 배치하고, 사용자가 바닥에서 200px 이내면 append 뒤 정확한 bottom으로 다시 맞춥니다.
+- 불확실한 DOM 구조 변경이 감지되면 공격적으로 full rebuild를 수행합니다.
+- detached node 압력이 임계값을 넘으면 해당 탭의 가상화를 끄고 새로고침으로 복구합니다.
+
+## 저장소 구조
+
+```text
+.
+├── public/manifest.json      # MV3 manifest 원본
+├── src/
+│   ├── background/           # popup/content 메시지를 처리하는 worker 로직
+│   ├── content/              # transcript 가상화 런타임
+│   ├── shared/               # 메시지 계약, 상수, 경로 파서, 타입
+│   ├── popup.ts              # popup 진입점
+│   ├── popup-view.ts         # popup view model
+│   ├── content.ts            # content script 진입점
+│   └── worker.ts             # service worker 진입점
+├── tests/
+│   ├── unit/                 # 순수 로직과 DOM 단위 테스트
+│   └── integration/          # Playwright 기반 브라우저 통합 테스트
+├── specs.md                  # 구현 순서와 세부 설계 메모
+├── whitepaper.md             # V1 동작 원칙과 제약
+└── todo.md                   # 작업 체크리스트
+```
+
+## 개발 명령
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run build
+pnpm run watch
+pnpm test
+pnpm run test:unit
+pnpm run test:integration
+```
+
+- `pnpm run build`: `dist/`에 `manifest.json`, `content.js`, `popup.html`, `popup.js`, `worker.js`를 생성합니다.
+- `pnpm run watch`: 개발 중 `dist/`를 계속 다시 빌드합니다.
+- `pnpm test`: unit + integration 테스트를 순서대로 실행합니다.
+
+## 문서
+
+- [Chrome에서 확장 로드하기](docs/chrome-extension-loading.md)
+- [구현 계획과 세부 스펙](specs.md)
+- [V1 제품 원칙](whitepaper.md)

--- a/docs/chrome-extension-loading.md
+++ b/docs/chrome-extension-loading.md
@@ -1,0 +1,96 @@
+# Chrome에서 확장 로드하기
+
+이 문서는 현재 저장소를 실제 Chrome 세션에 unpacked extension으로 로드하는 절차를 설명합니다. 목적은 `dist/` 산출물을 Chrome에 직접 불러오고, 팝업 상태와 기본 동작을 수동으로 확인할 수 있게 만드는 것입니다.
+
+## 사전 준비
+
+- Google Chrome
+- Node.js
+- pnpm
+- 이 저장소의 로컬 체크아웃
+
+## 1. 의존성 설치
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+잠금 파일 기준으로 의존성을 설치합니다.
+
+## 2. 확장 빌드
+
+```bash
+pnpm run build
+```
+
+빌드가 끝나면 `dist/` 아래에 Chrome이 읽을 unpacked extension 산출물이 생깁니다.
+
+- `dist/manifest.json`
+- `dist/content.js`
+- `dist/popup.html`
+- `dist/popup.js`
+- `dist/worker.js`
+
+개발 중 자동 재빌드가 필요하면 다음 명령을 별도 터미널에서 실행합니다.
+
+```bash
+pnpm run watch
+```
+
+## 3. Chrome에 unpacked extension 로드
+
+1. Chrome에서 `chrome://extensions`를 엽니다.
+2. 오른쪽 위 `개발자 모드`를 켭니다.
+3. `압축해제된 확장 프로그램을 로드합니다`를 클릭합니다.
+4. 이 저장소 루트가 아니라 `dist/` 디렉터리를 선택합니다.
+5. 카드 목록에 `cgpt-virtualizer`가 추가되면 로드가 끝난 것입니다.
+
+`dist/`가 아니라 저장소 루트를 선택하면 Chrome이 `manifest.json`을 찾지 못하므로 로드에 실패합니다.
+
+## 4. 기본 확인
+
+1. 필요하면 확장 아이콘을 툴바에 고정합니다.
+2. `https://chatgpt.com/c/<conversation-id>` 형태의 대화 페이지를 엽니다.
+3. 확장 팝업을 열어 토글과 상태 줄을 확인합니다.
+
+상태 해석은 다음과 같습니다.
+
+- `On`: 현재 탭에서 가상화가 켜져 있고, 콘텐츠 런타임이 사용 가능 상태입니다.
+- `Off`: 토글이 꺼져 있거나, 지원 경로가 아니거나, transcript bubble 수가 50개 미만이라 활성화되지 않았습니다.
+- `Unavailable`: selector 해석에 실패했거나 현재 세션에서 콘텐츠 런타임을 계속 진행할 수 없는 상태입니다.
+
+현재 코드의 selector registry는 실제 ChatGPT DOM 선택자가 아니라 테스트 fixture용 placeholder를 사용합니다. 그래서 확장을 Chrome에 정상 로드하더라도 live `chatgpt.com`에서는 `Unavailable`이 보일 수 있습니다. 이 문서는 로드 절차를 설명하는 문서이며, live 사이트 호환성 보장을 의미하지 않습니다.
+
+## 5. 코드 변경 후 다시 반영하기
+
+1. `pnpm run watch`로 `dist/`를 다시 빌드합니다.
+2. `chrome://extensions`로 돌아갑니다.
+3. `cgpt-virtualizer` 카드에서 새로고침 버튼을 눌러 확장을 다시 로드합니다.
+4. ChatGPT 탭도 새로고침해서 새 content script를 적용합니다.
+
+팝업에서 On/Off를 바꾸면 서비스 워커가 현재 탭을 새로고침하므로, 토글 이후에는 페이지가 다시 로드되는 것이 정상입니다.
+
+## 6. 자주 겪는 문제
+
+### 확장이 로드되지 않음
+
+- `pnpm run build`가 성공했는지 확인합니다.
+- `dist/manifest.json`이 존재하는지 확인합니다.
+- Chrome에서 선택한 디렉터리가 저장소 루트가 아니라 `dist/`인지 확인합니다.
+
+### 팝업이 계속 `Off`로 보임
+
+- 현재 URL이 `/c/:conversationId` 형태인지 확인합니다.
+- transcript bubble 수가 50개 이상인지 확인합니다.
+- 토글이 실제로 켜져 있는지 확인합니다.
+
+### 팝업이 `Unavailable`로 보임
+
+- 현재 구현은 placeholder selector를 사용하므로 live ChatGPT DOM에서는 이 상태가 정상일 수 있습니다.
+- mid-session selector failure가 발생하면 같은 페이지 세션에서는 inert 상태를 유지하므로 탭을 새로고침합니다.
+
+### 코드 변경이 Chrome에 반영되지 않음
+
+- `pnpm run watch` 또는 `pnpm run build`가 끝났는지 확인합니다.
+- `chrome://extensions`에서 확장 카드의 새로고침 버튼을 눌렀는지 확인합니다.
+- ChatGPT 탭 자체도 새로고침했는지 확인합니다.


### PR DESCRIPTION
## 요약
- 루트 `README.md`를 추가해 코드베이스 목적, 런타임 구성, 핵심 동작, 개발 명령을 정리했습니다.
- `docs/chrome-extension-loading.md`를 추가해 실제 Chrome 세션에서 `dist/`를 unpacked extension으로 로드하는 절차를 문서화했습니다.
- 현재 selector registry가 placeholder 기반이라 live ChatGPT에서 `Unavailable`이 나올 수 있다는 점을 문서에 명시했습니다.

## 테스트
- 미실행 (`README.md`, `docs/` 문서 변경만 포함)

## 이슈
- Closes #48