### PR TITLE
fix: 속성 기반 selector drift를 mid-session failure로 감지

### DIFF
--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -16,6 +16,7 @@ import {
   runDirtyRebuild,
 } from "./rebuild.ts";
 import {
+  collectObservedSelectorAttributes,
   createSelectorFailureObserverManager,
   handleSelectorStartupFailure,
   reportUnavailableStatus,
@@ -36,7 +37,7 @@ import {
   applyPendingAnchorCorrection,
   initializeScrollVirtualization,
 } from "./scroll.ts";
-import { resolveSelectors } from "./selectors.ts";
+import { CONTENT_SELECTOR_REGISTRY, resolveSelectors } from "./selectors.ts";
 import {
   buildBubbleRecords,
   markAllRecordsMounted,
@@ -50,6 +51,11 @@ import {
   scanTranscript,
   type TranscriptScanResult,
 } from "./transcript-scan.ts";
+
+const SELECTOR_FAILURE_ATTRIBUTE_FILTER = collectObservedSelectorAttributes([
+  CONTENT_SELECTOR_REGISTRY.scrollContainer,
+  CONTENT_SELECTOR_REGISTRY.transcriptRoot,
+]);
 
 export interface ContentBootstrapDependencies {
   clearTimeout?(handle: number): void;
@@ -311,6 +317,7 @@ export function bootstrapContentScript(
         },
       );
       selectorFailureObserverManager = createSelectorFailureObserverManager({
+        attributeFilter: SELECTOR_FAILURE_ATTRIBUTE_FILTER,
         createMutationObserver:
           dependencies.createMutationObserver ??
           ((callback) => new MutationObserver(callback)),

--- a/src/content/failure.ts
+++ b/src/content/failure.ts
@@ -2,6 +2,9 @@ import { createReportContentAvailabilityMessage } from "../shared/messages.ts";
 import type { MutationObserverLike } from "./append.ts";
 import type { ResolvedContentSelectors } from "./selectors.ts";
 
+const ATTRIBUTE_SELECTOR_PATTERN = /\[\s*([^\s~|^$*=\]]+)/g;
+const ATTRIBUTE_SEGMENT_PATTERN = /\[[^\]]*\]/g;
+
 type ReportAvailability = (
   message: ReturnType<typeof createReportContentAvailabilityMessage>,
 ) => void;
@@ -12,10 +15,38 @@ export interface SelectorFailureObserverManager {
 }
 
 export interface SelectorFailureObserverManagerDependencies {
+  attributeFilter?: string[];
   createMutationObserver(callback: MutationCallback): MutationObserverLike;
   document: Document;
   handleSelectorFailure(): void;
   resolveSelectors(document: Document): ResolvedContentSelectors | null;
+}
+
+export function collectObservedSelectorAttributes(
+  selectors: readonly string[],
+): string[] {
+  const attributes: string[] = [];
+
+  for (const selector of selectors) {
+    for (const match of selector.matchAll(ATTRIBUTE_SELECTOR_PATTERN)) {
+      pushUniqueAttribute(attributes, match[1]);
+    }
+
+    const selectorWithoutAttributeSegments = selector.replace(
+      ATTRIBUTE_SEGMENT_PATTERN,
+      "",
+    );
+
+    if (selectorWithoutAttributeSegments.includes(".")) {
+      pushUniqueAttribute(attributes, "class");
+    }
+
+    if (selectorWithoutAttributeSegments.includes("#")) {
+      pushUniqueAttribute(attributes, "id");
+    }
+  }
+
+  return attributes;
 }
 
 export function createSelectorFailureObserverManager(
@@ -42,10 +73,17 @@ export function createSelectorFailureObserverManager(
     sync();
   });
 
-  observer.observe(observationRoot, {
+  const observeOptions: MutationObserverInit = {
     childList: true,
     subtree: true,
-  });
+  };
+
+  if ((dependencies.attributeFilter?.length ?? 0) > 0) {
+    observeOptions.attributeFilter = dependencies.attributeFilter;
+    observeOptions.attributes = true;
+  }
+
+  observer.observe(observationRoot, observeOptions);
 
   return {
     disconnect() {
@@ -67,4 +105,12 @@ export function reportUnavailableStatus(
   reportAvailability: ReportAvailability,
 ): void {
   reportAvailability(createReportContentAvailabilityMessage("unavailable"));
+}
+
+function pushUniqueAttribute(attributes: string[], attribute: string): void {
+  if (attributes.includes(attribute)) {
+    return;
+  }
+
+  attributes.push(attribute);
 }

--- a/src/content/failure.ts
+++ b/src/content/failure.ts
@@ -2,7 +2,11 @@ import { createReportContentAvailabilityMessage } from "../shared/messages.ts";
 import type { MutationObserverLike } from "./append.ts";
 import type { ResolvedContentSelectors } from "./selectors.ts";
 
+// 단순 속성 선택자만 처리한다 (예: [attr], [attr=val], [attr^=val]).
+// 따옴표 안에 ']'가 포함된 값은 지원하지 않는다.
 const ATTRIBUTE_SELECTOR_PATTERN = /\[\s*([^\s~|^$*=\]]+)/g;
+// 속성 세그먼트를 제거한 뒤 '.', '#' 존재 여부로 class/id 의존성을 판별한다.
+// 따옴표 안에 ']'가 포함된 속성 값은 지원하지 않는다.
 const ATTRIBUTE_SEGMENT_PATTERN = /\[[^\]]*\]/g;
 
 type ReportAvailability = (

--- a/tests/integration/content-bootstrap.spec.ts
+++ b/tests/integration/content-bootstrap.spec.ts
@@ -310,6 +310,89 @@ test("mid-session selector failure는 Unavailable로 전환되고 navigation 전
     });
 });
 
+test("mid-session selector attribute drift도 Unavailable로 전환되고 navigation 전까지 inert 상태를 유지한다", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const helperPage = await openEnabledFixture(
+    page,
+    context,
+    extensionId,
+    "/c/bubble-50?fixture=bubble-50",
+  );
+  await expectPopupState(helperPage, {
+    enabled: true,
+    status: "On",
+  });
+
+  await expectInitialMountedWindow(page);
+
+  await page.evaluate(async () => {
+    const scrollContainer = document.querySelector<HTMLElement>(
+      "[data-cgpt-scroll-container]",
+    );
+
+    if (scrollContainer === null) {
+      throw new Error("scroll container fixture is missing");
+    }
+
+    (window as WindowWithTestState).__detachedScrollContainer = scrollContainer;
+    scrollContainer.removeAttribute("data-cgpt-scroll-container");
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+
+  await expectPopupState(helperPage, {
+    enabled: true,
+    status: "Unavailable",
+  });
+
+  await page.evaluate(() => {
+    const detachedScrollContainer = (window as WindowWithTestState)
+      .__detachedScrollContainer;
+
+    if (detachedScrollContainer === undefined) {
+      throw new Error("detached scroll container fixture is missing");
+    }
+
+    detachedScrollContainer.scrollTop = 400;
+    detachedScrollContainer.dispatchEvent(new Event("scroll"));
+  });
+
+  await page.evaluate(async () => {
+    history.pushState({}, "", "/c/recovered?fixture=bubble-50-alt");
+    (window as WindowWithTestState).__replaceFixture("bubble-50-alt");
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+
+  await expectPopupState(helperPage, {
+    enabled: true,
+    status: "On",
+  });
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const transcriptRoot = document.querySelector(
+          "[data-cgpt-transcript-root]",
+        );
+        const children =
+          transcriptRoot === null ? [] : Array.from(transcriptRoot.children);
+
+        return {
+          firstBubbleText: children[1]?.textContent ?? null,
+          lastBubbleText: children.at(-2)?.textContent ?? null,
+        };
+      }),
+    )
+    .toEqual({
+      firstBubbleText: "Next Bubble 0",
+      lastBubbleText: "Next Bubble 3",
+    });
+});
+
 test("conversation ID가 바뀌면 현재 세션을 폐기하고 새 transcript를 처음부터 다시 초기화한다", async ({
   context,
   extensionId,

--- a/tests/unit/content-failure.test.ts
+++ b/tests/unit/content-failure.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  collectObservedSelectorAttributes,
+  createSelectorFailureObserverManager,
+} from "../../src/content/failure.ts";
+
+describe("collectObservedSelectorAttributes", () => {
+  it("collects selector-relevant attribute names from exact selectors", () => {
+    expect(
+      collectObservedSelectorAttributes([
+        "[data-cgpt-scroll-container]",
+        "main[data-cgpt-transcript-root].is-ready #transcript",
+      ]),
+    ).toEqual([
+      "data-cgpt-scroll-container",
+      "data-cgpt-transcript-root",
+      "class",
+      "id",
+    ]);
+  });
+});
+
+describe("createSelectorFailureObserverManager", () => {
+  it("observes childList and selector-relevant attribute drift", () => {
+    const observe = vi.fn();
+
+    createSelectorFailureObserverManager({
+      attributeFilter: ["data-cgpt-scroll-container", "class"],
+      createMutationObserver() {
+        return {
+          disconnect() {},
+          observe,
+          takeRecords() {
+            return [];
+          },
+        };
+      },
+      document,
+      handleSelectorFailure() {},
+      resolveSelectors() {
+        return {
+          bubbleSelector: "[data-cgpt-transcript-bubble]",
+          scrollContainer: document.createElement("main"),
+          streamingIndicatorSelector: "[data-cgpt-streaming-indicator]",
+          transcriptRoot: document.createElement("section"),
+        };
+      },
+    });
+
+    expect(observe).toHaveBeenCalledWith(document.body, {
+      attributeFilter: ["data-cgpt-scroll-container", "class"],
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
+  });
+
+  it("treats watched attribute-only drift as selector failure", () => {
+    let callback: MutationCallback | null = null;
+    const handleSelectorFailure = vi.fn();
+
+    createSelectorFailureObserverManager({
+      attributeFilter: ["data-cgpt-scroll-container"],
+      createMutationObserver(nextCallback) {
+        callback = nextCallback;
+
+        return {
+          disconnect() {},
+          observe() {},
+          takeRecords() {
+            return [];
+          },
+        };
+      },
+      document,
+      handleSelectorFailure,
+      resolveSelectors() {
+        return null;
+      },
+    });
+
+    if (callback === null) {
+      throw new Error("selector failure observer callback was not registered");
+    }
+
+    callback(
+      [
+        {
+          addedNodes: [] as unknown as NodeList,
+          attributeName: "data-cgpt-scroll-container",
+          attributeNamespace: null,
+          nextSibling: null,
+          oldValue: "",
+          previousSibling: null,
+          removedNodes: [] as unknown as NodeList,
+          target: document.body,
+          type: "attributes",
+        } as MutationRecord,
+      ],
+      {} as MutationObserver,
+    );
+
+    expect(handleSelectorFailure).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 요약
- selector failure observer가 selector-relevant attribute drift도 감지하도록 확장했습니다
- scroll container와 transcript root selector에서 관찰할 attribute 목록을 계산해 filtered observation으로 연결했습니다
- attribute-only drift가 발생해도 기존 removal 기반 selector failure와 같은 fail-closed 경로를 타도록 유지했습니다
- unit/integration 회귀 테스트를 추가했습니다

## 검증
- 
> cgpt-virtualizer@0.0.0 test:unit /Users/ori/repos/cgpt-virtualizer/.worktrees/fix-issue-58-selector-drift-attributes
> vitest run


 RUN  v4.0.18 /Users/ori/repos/cgpt-virtualizer/.worktrees/fix-issue-58-selector-drift-attributes

 ✓ tests/unit/transcript-scan.test.ts (12 tests) 9ms
 ✓ tests/unit/content-resize.test.ts (5 tests) 11ms
 ✓ tests/unit/content-debug.test.ts (3 tests) 15ms
 ✓ tests/unit/content-scroll.test.ts (3 tests) 10ms
 ✓ tests/unit/content-rebuild.test.ts (5 tests) 25ms
 ✓ tests/unit/content-placeholder.test.ts (4 tests) 39ms
 ✓ tests/unit/content-append.test.ts (9 tests) 40ms
 ✓ tests/unit/content-streaming.test.ts (3 tests) 70ms
 ✓ tests/unit/content-bootstrap.test.ts (15 tests) 43ms
 ✓ tests/unit/content-controller.test.ts (7 tests) 3ms
 ✓ tests/unit/shared.test.ts (5 tests) 3ms
 ✓ tests/unit/popup-worker.test.ts (22 tests) 5ms
 ✓ tests/unit/content-startup.test.ts (2 tests) 4ms
 ✓ tests/unit/smoke.test.ts (1 test) 2ms
 ✓ tests/unit/measurement-prefix-sums.test.ts (10 tests) 6ms
 ✓ tests/unit/content-memory-guard.test.ts (4 tests) 6ms
 ✓ tests/unit/content-patch.test.ts (4 tests) 13ms
 ✓ tests/unit/content-navigation.test.ts (5 tests) 14ms
 ✓ tests/unit/content-anchor.test.ts (7 tests) 2ms
 ✓ tests/unit/content-failure.test.ts (3 tests) 2ms
 ✓ tests/unit/content-bottom-follow.test.ts (3 tests) 2ms
 ✓ tests/unit/content-range.test.ts (6 tests) 1ms

 Test Files  22 passed (22)
      Tests  138 passed (138)
   Start at  17:59:47
   Duration  1.58s (transform 729ms, setup 0ms, import 1.22s, tests 327ms, environment 8.17s)
- 
Running 28 tests using 1 worker





[1A[2K[1/28] [extension] › tests/integration/content-bootstrap.spec.ts:7:1 › 비대상 경로에서는 활성화 후에도 Off 상태로 남는다
[1A[2K[2/28] [extension] › tests/integration/content-bootstrap.spec.ts:41:1 › 지원 경로에서 필수 선택자가 없으면 Unavailable을 보고한다
[1A[2K[3/28] [extension] › tests/integration/content-bootstrap.spec.ts:59:1 › 지원 경로에서 bubble이 threshold 미만이면 inactive를 보고한다
[1A[2K[4/28] [extension] › tests/integration/content-bootstrap.spec.ts:77:1 › bubble이 0개일 때 inactive를 보고하고 오류 없이 실행된다
[1A[2K[5/28] [extension] › tests/integration/content-bootstrap.spec.ts:103:1 › bubble이 49개일 때 inactive를 보고하고 오류 없이 실행된다
[1A[2K[6/28] [extension] › tests/integration/content-bootstrap.spec.ts:129:1 › bubble이 50개일 때 available을 보고하고 오류 없이 실행된다
[1A[2K[7/28] [extension] › tests/integration/content-bootstrap.spec.ts:147:1 › bubble이 50개일 때 spacer와 전체 mounted range를 초기 패치한다
[1A[2K[8/28] [extension] › tests/integration/content-bootstrap.spec.ts:194:1 › memory guard 임계값을 넘으면 탭 비활성화 요청을 보내고 transcript DOM을 복구한다
[1A[2K[9/28] [extension] › tests/integration/content-bootstrap.spec.ts:236:1 › mid-session selector failure는 Unavailable로 전환되고 navigation 전까지 inert 상태를 유지한다
[1A[2K[10/28] [extension] › tests/integration/content-bootstrap.spec.ts:313:1 › mid-session selector attribute drift도 Unavailable로 전환되고 navigation 전까지 inert 상태를 유지한다
[1A[2K[11/28] [extension] › tests/integration/content-bootstrap.spec.ts:396:1 › conversation ID가 바뀌면 현재 세션을 폐기하고 새 transcript를 처음부터 다시 초기화한다
[1A[2K[12/28] [extension] › tests/integration/content-bootstrap.spec.ts:455:1 › 비 transcript 경로로 이동하면 활성 세션을 해제하고 Off 상태로 남는다
[1A[2K[13/28] [extension] › tests/integration/content-bootstrap.spec.ts:514:1 › 같은 conversation ID의 네비게이션 신호는 파괴적 재초기화를 일으키지 않는다
[1A[2K[14/28] [extension] › tests/integration/content-bootstrap.spec.ts:573:1 › 스크롤로 mounted range가 바뀌면 mounted range를 갱신한다
[1A[2K[15/28] [extension] › tests/integration/content-bootstrap.spec.ts:621:1 › range가 바뀌지 않는 scroll은 mounted range를 유지한다
[1A[2K[16/28] [extension] › tests/integration/content-bootstrap.spec.ts:701:1 › streaming 중 scroll은 mounted range 패치를 멈춘다
[1A[2K[17/28] [extension] › tests/integration/content-bootstrap.spec.ts:755:1 › streaming 종료 후에는 scroll-driven mounted range patch가 다시 동작한다
[1A[2K[18/28] [extension] › tests/integration/content-bootstrap.spec.ts:818:1 › streaming gap에 진입하면 placeholder를 표시하고 종료 시 제거한다
[1A[2K[19/28] [extension] › tests/integration/content-bootstrap.spec.ts:912:1 › streaming 중 resize는 anchor correction을 계속 적용한다
[1A[2K[20/28] [extension] › tests/integration/content-bootstrap.spec.ts:1021:1 › mounted bubble resize는 prefix sum과 mounted range를 갱신한다
[1A[2K[21/28] [extension] › tests/integration/content-bootstrap.spec.ts:1085:1 › detached bubble resize는 관찰되지 않는다
[1A[2K[22/28] [extension] › tests/integration/content-bootstrap.spec.ts:1134:1 › anchor 위 bubble resize는 읽기 위치를 유지한다
[1A[2K[23/28] [extension] › tests/integration/content-bootstrap.spec.ts:1235:1 › streaming 종료 시 pending append batch를 즉시 flush한다
[1A[2K[24/28] [extension] › tests/integration/content-bootstrap.spec.ts:1325:1 › near-bottom append는 새 tail을 mount하고 exact bottom으로 따라간다
[1A[2K[25/28] [extension] › tests/integration/content-bootstrap.spec.ts:1430:1 › non-near-bottom append burst는 detached tail로 남는다
[1A[2K[26/28] [extension] › tests/integration/content-bootstrap.spec.ts:1498:1 › mid-list removal은 dirty rebuild를 트리거하고 surviving anchor 위치를 복원한다
[1A[2K[27/28] [extension] › tests/integration/content-bootstrap.spec.ts:1592:1 › anchor bubble가 사라지면 dirty rebuild는 raw scrollTop fallback을 사용한다
[1A[2K[28/28] [extension] › tests/integration/content-bootstrap.spec.ts:1656:1 › dirty rebuild 뒤에도 append observer가 다시 연결된다
[1A[2K  28 passed (27.8s)
- 
Running 1 test using 1 worker





[1A[2K[1/1] [extension] › tests/integration/content-bootstrap.spec.ts:313:1 › mid-session selector attribute drift도 Unavailable로 전환되고 navigation 전까지 inert 상태를 유지한다
[1A[2K  1 passed (1.7s)

Closes #58