### PR TITLE
refactor(test): 시각 smoke 테스트 리뷰 피드백 반영

### DIFF
--- a/tests/integration/chatgpt-fixture.ts
+++ b/tests/integration/chatgpt-fixture.ts
@@ -31,7 +31,7 @@ export async function openEnabledFixture(
   return helperPage;
 }
 
-export async function openHelperPage(
+async function openHelperPage(
   context: BrowserContext,
   extensionId: string,
 ): Promise<Page> {
@@ -40,7 +40,7 @@ export async function openHelperPage(
   return helperPage;
 }
 
-export async function setExtensionEnabled(
+async function setExtensionEnabled(
   helperPage: Page,
   enabled: boolean,
 ): Promise<void> {
@@ -68,7 +68,7 @@ export async function setExtensionEnabled(
   }, enabled);
 }
 
-export async function getPopupState(helperPage: Page): Promise<PopupState> {
+async function getPopupState(helperPage: Page): Promise<PopupState> {
   return helperPage.evaluate(async () => {
     const tabs = await chrome.tabs.query({
       url: ["https://chatgpt.com/*"],

--- a/tests/integration/visual-smoke.spec.ts
+++ b/tests/integration/visual-smoke.spec.ts
@@ -5,8 +5,6 @@ import {
   openEnabledFixture,
 } from "./chatgpt-fixture.ts";
 
-test.describe.configure({ mode: "serial" });
-
 test("팝업 On 상태가 일관되게 렌더링된다", async ({
   context,
   extensionId,
@@ -50,12 +48,13 @@ test("transcript 초기 mounted window가 일관되게 렌더링된다", async (
     width: 1280,
   });
 
-  await openEnabledFixture(
+  const helperPage = await openEnabledFixture(
     page,
     context,
     extensionId,
     "/c/bubble-50?fixture=bubble-50",
   );
+  await helperPage.close();
 
   await expectInitialMountedWindow(page);
   await expect(page.locator("[data-cgpt-scroll-container]")).toHaveScreenshot(

--- a/tests/integration/visual-snapshots.css
+++ b/tests/integration/visual-snapshots.css
@@ -1,3 +1,9 @@
+/*
+ * 시각 smoke 테스트용 합성 스타일시트.
+ * 실제 확장 UI가 아니라 fixture HTML의 DOM 구조가 올바르게
+ * 마운트되었는지 검증하기 위한 결정론적 외관을 제공한다.
+ */
+
 :root {
   color-scheme: light;
 }


### PR DESCRIPTION
## 요약

- PR #63 머지 후 반영되지 못한 코드 리뷰 피드백을 적용합니다.
- 내부 전용 헬퍼 export 제거, 불필요한 serial 모드 제거, helperPage 명시적 정리, CSS 목적 주석 추가.

## 검증

- `pnpm exec tsc --noEmit` 통과
- 기존 테스트에 영향 없음 (export 제거 대상은 외부에서 미사용)

## 이슈

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)