### PR TITLE
feat(selectors): 다중 후보 선택자 인프라 추가 (#53)

### DIFF
--- a/docs/journal/journal-2026-04-24-pr70-merge-conflicts.md
+++ b/docs/journal/journal-2026-04-24-pr70-merge-conflicts.md
@@ -1,0 +1,18 @@
+# Journal 2026-04-24 PR70 Merge Conflicts
+
+## Context
+
+- Task: handle merge conflicts on PR `#70` (`feature/53-selector-infrastructure` into `main`).
+- Local `main` was fast-forwarded from `d60d712` to `05b8ceb` before conflict work started.
+- Existing clean worktree for the PR branch was available at `.worktrees/issue-53-selector-infrastructure`.
+
+## Resolution
+
+- Merged updated `main` into `feature/53-selector-infrastructure` inside the existing PR worktree.
+- Resolved the explicit conflict in `tests/unit/content-selectors.test.ts` by preserving both the default-registry coverage added on `main` and the multi-candidate selector coverage from the PR branch.
+- Patched `src/content/bootstrap.ts` so startup discovery attribute filters flatten selector candidate arrays before passing them to `collectObservedSelectorAttributes()`. This avoids a bad post-merge type/behavior mismatch introduced by the auto-merge.
+
+## Verification
+
+- `pnpm run test:unit`
+- `pnpm run build`

--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -36,7 +36,11 @@ import {
   applyPendingAnchorCorrection,
   initializeScrollVirtualization,
 } from "./scroll.ts";
-import { CONTENT_SELECTOR_REGISTRY, resolveSelectors } from "./selectors.ts";
+import {
+  CONTENT_SELECTOR_REGISTRY,
+  normalizeCandidates,
+  resolveSelectors,
+} from "./selectors.ts";
 import {
   buildBubbleRecords,
   markAllRecordsMounted,
@@ -52,13 +56,13 @@ import {
 } from "./transcript-scan.ts";
 
 const SELECTOR_FAILURE_ATTRIBUTE_FILTER = collectObservedSelectorAttributes([
-  CONTENT_SELECTOR_REGISTRY.scrollContainer,
-  CONTENT_SELECTOR_REGISTRY.transcriptRoot,
+  ...normalizeCandidates(CONTENT_SELECTOR_REGISTRY.scrollContainer),
+  ...normalizeCandidates(CONTENT_SELECTOR_REGISTRY.transcriptRoot),
 ]);
 const STARTUP_DISCOVERY_ATTRIBUTE_FILTER = collectObservedSelectorAttributes([
-  CONTENT_SELECTOR_REGISTRY.bubble,
-  CONTENT_SELECTOR_REGISTRY.scrollContainer,
-  CONTENT_SELECTOR_REGISTRY.transcriptRoot,
+  ...normalizeCandidates(CONTENT_SELECTOR_REGISTRY.bubble),
+  ...normalizeCandidates(CONTENT_SELECTOR_REGISTRY.scrollContainer),
+  ...normalizeCandidates(CONTENT_SELECTOR_REGISTRY.transcriptRoot),
 ]);
 
 const STARTUP_DISCOVERY_TIMEOUT_MS = 10_000;

--- a/src/content/selectors.ts
+++ b/src/content/selectors.ts
@@ -1,8 +1,9 @@
+// 각 역할마다 우선순위 순서로 시도할 후보 선택자를 하나 또는 여럿 지정할 수 있다.
 export interface ContentSelectorRegistry {
-  bubble: string;
-  scrollContainer: string;
-  streamingIndicator: string;
-  transcriptRoot: string;
+  bubble: string | readonly string[];
+  scrollContainer: string | readonly string[];
+  streamingIndicator: string | readonly string[];
+  transcriptRoot: string | readonly string[];
 }
 
 export interface ResolvedContentSelectors {
@@ -12,33 +13,57 @@ export interface ResolvedContentSelectors {
   transcriptRoot: HTMLElement;
 }
 
+// 이 레지스트리의 선택자는 테스트 픽스처 전용 플레이스홀더다.
+// 실제 ChatGPT DOM 선택자는 인증된 세션에서 직접 확인한 뒤 배열의 첫 번째 항목으로
+// 추가해야 한다. 픽스처 플레이스홀더는 폴백으로 유지한다.
+// 예시: bubble: ["실제-선택자", "[data-cgpt-transcript-bubble]"]
 export const CONTENT_SELECTOR_REGISTRY: ContentSelectorRegistry = {
-  // 실제 ChatGPT 선택자가 확인되면 이 자리의 정확한 선택자로 교체한다.
   bubble: "[data-cgpt-transcript-bubble]",
   scrollContainer: "[data-cgpt-scroll-container]",
   streamingIndicator: "[data-cgpt-streaming-indicator]",
   transcriptRoot: "[data-cgpt-transcript-root]",
 };
 
+// string | readonly string[] 값을 readonly string[] 로 정규화한다.
+export function normalizeCandidates(
+  candidates: string | readonly string[],
+): readonly string[] {
+  return typeof candidates === "string" ? [candidates] : candidates;
+}
+
+// 후보 선택자 목록에서 DOM에 존재하는 첫 번째 요소를 반환한다.
+function resolveElement(
+  document: Document,
+  candidates: string | readonly string[],
+): HTMLElement | null {
+  const list = normalizeCandidates(candidates);
+  for (const sel of list) {
+    const el = document.querySelector<HTMLElement>(sel);
+    if (el !== null) return el;
+  }
+  return null;
+}
+
+// 후보 선택자 목록을 쉼표로 결합하여 복합 CSS 선택자 문자열을 만든다.
+function joinCandidates(candidates: string | readonly string[]): string {
+  return normalizeCandidates(candidates).join(",");
+}
+
 export function resolveSelectors(
   document: Document,
   registry: ContentSelectorRegistry = CONTENT_SELECTOR_REGISTRY,
 ): ResolvedContentSelectors | null {
-  const scrollContainer = document.querySelector<HTMLElement>(
-    registry.scrollContainer,
-  );
-  const transcriptRoot = document.querySelector<HTMLElement>(
-    registry.transcriptRoot,
-  );
+  const scrollContainer = resolveElement(document, registry.scrollContainer);
+  const transcriptRoot = resolveElement(document, registry.transcriptRoot);
 
   if (scrollContainer === null || transcriptRoot === null) {
     return null;
   }
 
   return {
-    bubbleSelector: registry.bubble,
+    bubbleSelector: joinCandidates(registry.bubble),
     scrollContainer,
-    streamingIndicatorSelector: registry.streamingIndicator,
+    streamingIndicatorSelector: joinCandidates(registry.streamingIndicator),
     transcriptRoot,
   };
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,7 +4,10 @@ import {
 } from "./shared/messages.ts";
 import { handleContentMessage } from "./background/content-controller.ts";
 import { handlePopupMessage } from "./background/popup-controller.ts";
-import { createTabStateStore, type StorageBackend } from "./background/tab-state.ts";
+import {
+  createTabStateStore,
+  type StorageBackend,
+} from "./background/tab-state.ts";
 
 const sessionStorage: StorageBackend = {
   async get(key) {

--- a/tests/unit/content-selectors.test.ts
+++ b/tests/unit/content-selectors.test.ts
@@ -7,56 +7,55 @@ import {
   type ContentSelectorRegistry,
 } from "../../src/content/selectors.ts";
 
+function makeDocument(selectors: readonly string[]): Document {
+  const doc = document.implementation.createHTMLDocument();
+  for (const selector of selectors) {
+    // 속성 선택자 [data-foo="bar"] 또는 [data-foo] 형태를 지원한다
+    const match = /^\[([^\]=]+)(?:="([^"]*)")?\]$/.exec(selector);
+    if (match) {
+      const el = doc.createElement("div");
+      el.setAttribute(match[1], match[2] ?? "");
+      doc.body.appendChild(el);
+    }
+  }
+  return doc;
+}
+
+const BASE: ContentSelectorRegistry = {
+  bubble: "[data-cgpt-transcript-bubble]",
+  scrollContainer: "[data-cgpt-scroll-container]",
+  streamingIndicator: "[data-cgpt-streaming-indicator]",
+  transcriptRoot: "[data-cgpt-transcript-root]",
+};
+
 describe("resolveSelectors", () => {
   it("returns null when the scroll container is missing", () => {
-    const body = document.createElement("body");
-    const transcriptRoot = document.createElement("section");
-    transcriptRoot.setAttribute("data-cgpt-transcript-root", "");
-    body.append(transcriptRoot);
-
-    const doc = {
-      querySelector(selector: string) {
-        return body.querySelector(selector);
-      },
-    } as unknown as Document;
+    const doc = makeDocument(["[data-cgpt-transcript-root]"]);
 
     expect(resolveSelectors(doc)).toBeNull();
   });
 
   it("returns null when the transcript root is missing", () => {
-    const body = document.createElement("body");
-    const scrollContainer = document.createElement("main");
-    scrollContainer.setAttribute("data-cgpt-scroll-container", "");
-    body.append(scrollContainer);
-
-    const doc = {
-      querySelector(selector: string) {
-        return body.querySelector(selector);
-      },
-    } as unknown as Document;
+    const doc = makeDocument(["[data-cgpt-scroll-container]"]);
 
     expect(resolveSelectors(doc)).toBeNull();
   });
 
   it("returns the resolved elements when both are present", () => {
-    const body = document.createElement("body");
-    const scrollContainer = document.createElement("main");
-    scrollContainer.setAttribute("data-cgpt-scroll-container", "");
-    const transcriptRoot = document.createElement("section");
-    transcriptRoot.setAttribute("data-cgpt-transcript-root", "");
-    body.append(scrollContainer, transcriptRoot);
-
-    const doc = {
-      querySelector(selector: string) {
-        return body.querySelector(selector);
-      },
-    } as unknown as Document;
+    const doc = makeDocument([
+      "[data-cgpt-scroll-container]",
+      "[data-cgpt-transcript-root]",
+    ]);
 
     const result = resolveSelectors(doc);
 
     expect(result).not.toBeNull();
-    expect(result?.scrollContainer).toBe(scrollContainer);
-    expect(result?.transcriptRoot).toBe(transcriptRoot);
+    expect(result?.scrollContainer).toBe(
+      doc.querySelector<HTMLElement>("[data-cgpt-scroll-container]"),
+    );
+    expect(result?.transcriptRoot).toBe(
+      doc.querySelector<HTMLElement>("[data-cgpt-transcript-root]"),
+    );
     expect(result?.bubbleSelector).toBe(CONTENT_SELECTOR_REGISTRY.bubble);
     expect(result?.streamingIndicatorSelector).toBe(
       CONTENT_SELECTOR_REGISTRY.streamingIndicator,
@@ -70,31 +69,132 @@ describe("resolveSelectors", () => {
       streamingIndicator: "[data-test-streaming]",
       transcriptRoot: "[data-test-root]",
     };
-
-    const body = document.createElement("body");
-    const scrollContainer = document.createElement("main");
-    scrollContainer.setAttribute("data-test-scroll", "");
-    const transcriptRoot = document.createElement("section");
-    transcriptRoot.setAttribute("data-test-root", "");
-    body.append(scrollContainer, transcriptRoot);
-
-    const doc = {
-      querySelector(selector: string) {
-        return body.querySelector(selector);
-      },
-    } as unknown as Document;
+    const doc = makeDocument(["[data-test-scroll]", "[data-test-root]"]);
 
     const result = resolveSelectors(doc, customRegistry);
 
     expect(result).not.toBeNull();
-    expect(result?.scrollContainer).toBe(scrollContainer);
-    expect(result?.transcriptRoot).toBe(transcriptRoot);
+    expect(result?.scrollContainer).toBe(
+      doc.querySelector<HTMLElement>("[data-test-scroll]"),
+    );
+    expect(result?.transcriptRoot).toBe(
+      doc.querySelector<HTMLElement>("[data-test-root]"),
+    );
     expect(result?.bubbleSelector).toBe(customRegistry.bubble);
     expect(result?.streamingIndicatorSelector).toBe(
       customRegistry.streamingIndicator,
     );
 
-    // Default registry selectors should not match elements built for the custom registry
+    // Default registry selectors should not match elements built for the custom registry.
     expect(resolveSelectors(doc)).toBeNull();
+  });
+
+  it("단일 문자열은 기존과 동일하게 동작한다", () => {
+    const doc = makeDocument([
+      "[data-cgpt-scroll-container]",
+      "[data-cgpt-transcript-root]",
+    ]);
+
+    const result = resolveSelectors(doc, BASE);
+
+    expect(result).not.toBeNull();
+    expect(result!.bubbleSelector).toBe("[data-cgpt-transcript-bubble]");
+    expect(result!.streamingIndicatorSelector).toBe(
+      "[data-cgpt-streaming-indicator]",
+    );
+  });
+
+  it("배열에서 첫 번째 후보가 DOM에 있으면 첫 번째를 사용한다", () => {
+    const doc = makeDocument([
+      "[data-first]",
+      "[data-cgpt-scroll-container]",
+      "[data-cgpt-transcript-root]",
+    ]);
+
+    const registry: ContentSelectorRegistry = {
+      ...BASE,
+      scrollContainer: ["[data-first]", "[data-second]"],
+    };
+
+    const result = resolveSelectors(doc, registry);
+
+    expect(result).not.toBeNull();
+    expect(result!.scrollContainer).toBe(
+      doc.querySelector<HTMLElement>("[data-first]"),
+    );
+  });
+
+  it("배열에서 첫 번째 후보가 없고 두 번째가 있으면 두 번째를 사용한다", () => {
+    const doc = makeDocument([
+      "[data-second]",
+      "[data-cgpt-scroll-container]",
+      "[data-cgpt-transcript-root]",
+    ]);
+
+    const registry: ContentSelectorRegistry = {
+      ...BASE,
+      scrollContainer: ["[data-first]", "[data-second]"],
+    };
+
+    const result = resolveSelectors(doc, registry);
+
+    expect(result).not.toBeNull();
+    expect(result!.scrollContainer).toBe(
+      doc.querySelector<HTMLElement>("[data-second]"),
+    );
+  });
+
+  it("배열의 모든 후보가 DOM에 없으면 null을 반환한다", () => {
+    const doc = makeDocument(["[data-cgpt-transcript-root]"]);
+
+    const registry: ContentSelectorRegistry = {
+      ...BASE,
+      scrollContainer: ["[data-first]", "[data-second]"],
+    };
+
+    const result = resolveSelectors(doc, registry);
+
+    expect(result).toBeNull();
+  });
+
+  it("bubble이 배열이면 쉼표로 결합된 복합 선택자를 반환한다", () => {
+    const doc = makeDocument([
+      "[data-cgpt-scroll-container]",
+      "[data-cgpt-transcript-root]",
+    ]);
+
+    const registry: ContentSelectorRegistry = {
+      ...BASE,
+      bubble: ["[data-real-bubble]", "[data-cgpt-transcript-bubble]"],
+    };
+
+    const result = resolveSelectors(doc, registry);
+
+    expect(result).not.toBeNull();
+    expect(result!.bubbleSelector).toBe(
+      "[data-real-bubble],[data-cgpt-transcript-bubble]",
+    );
+  });
+
+  it("streamingIndicator가 배열이면 쉼표로 결합된 복합 선택자를 반환한다", () => {
+    const doc = makeDocument([
+      "[data-cgpt-scroll-container]",
+      "[data-cgpt-transcript-root]",
+    ]);
+
+    const registry: ContentSelectorRegistry = {
+      ...BASE,
+      streamingIndicator: [
+        "[data-real-indicator]",
+        "[data-cgpt-streaming-indicator]",
+      ],
+    };
+
+    const result = resolveSelectors(doc, registry);
+
+    expect(result).not.toBeNull();
+    expect(result!.streamingIndicatorSelector).toBe(
+      "[data-real-indicator],[data-cgpt-streaming-indicator]",
+    );
   });
 });

--- a/tests/unit/popup-worker.test.ts
+++ b/tests/unit/popup-worker.test.ts
@@ -125,9 +125,7 @@ describe("tab state store", () => {
     const store = createTabStateStore(createInMemoryStorage());
 
     await expect(store.getTabPreference(7)).resolves.toBe(false);
-    expect(
-      createPopupState(7, false, "idle"),
-    ).toEqual({
+    expect(createPopupState(7, false, "idle")).toEqual({
       enabled: false,
       status: "Off",
     });
@@ -142,9 +140,7 @@ describe("tab state store", () => {
 
     await expect(store.getTabPreference(7)).resolves.toBe(true);
     await expect(store.getTabPreference(9)).resolves.toBe(false);
-    expect(
-      createPopupState(7, true, "available"),
-    ).toEqual({
+    expect(createPopupState(7, true, "available")).toEqual({
       enabled: true,
       status: "On",
     });


### PR DESCRIPTION
## Summary

- `ContentSelectorRegistry`의 각 필드가 `string | readonly string[]`을 수용하도록 인터페이스를 확장한다
- `resolveSelectors()`가 배열 후보를 우선순위 순서로 시도하고 첫 번째 일치 요소를 반환한다
- `bubble`/`streamingIndicator`는 배열을 쉼표 결합 복합 CSS 선택자로 변환한다
- `normalizeCandidates()` 유틸리티를 export하여 소비 코드(bootstrap.ts)가 후보 목록을 평탄화할 수 있도록 한다
- `CONTENT_SELECTOR_REGISTRY` 주석을 업데이트하여 플레이스홀더 용도와 실제 선택자 추가 방법을 문서화한다
- 6개의 단위 테스트를 추가한다: 단일 문자열, 첫 번째 후보 우선, 폴백, 전체 미일치 → null, bubble 복합 선택자, streamingIndicator 복합 선택자

**This PR does not add real ChatGPT DOM selectors. The multi-candidate infrastructure is in place, but the actual selector values for the real ChatGPT DOM need to be filled in by someone who can inspect a live authenticated ChatGPT session.**

## Test plan

- [x] `pnpm run test:unit` — 144개 테스트 전부 통과
- [x] `pnpm run build` — 빌드 오류 없음
- [x] 기존 선택자 플레이스홀더 값은 변경하지 않음
- [x] 인위적인 실제 ChatGPT 선택자를 추가하지 않음

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)